### PR TITLE
[DABOM-84] 가족 정책 관리(조회/수정) 기능 구현

### DIFF
--- a/src/main/java/com/project/customer/infra/entity/BaseJpaEntity.java
+++ b/src/main/java/com/project/customer/infra/entity/BaseJpaEntity.java
@@ -2,16 +2,21 @@ package com.project.customer.infra.entity;
 
 import java.time.LocalDateTime;
 
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import lombok.Getter;
 
 @MappedSuperclass
 @Getter
+@EntityListeners(AuditingEntityListener.class)
 public class BaseJpaEntity {
-    private LocalDateTime createdAt;
-
-    private LocalDateTime updatedAt;
+    @CreatedDate private LocalDateTime createdAt;
+    @LastModifiedDate private LocalDateTime updatedAt;
 
     private LocalDateTime deletedAt;
 }

--- a/src/main/java/com/project/global/config/WebConfig.java
+++ b/src/main/java/com/project/global/config/WebConfig.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -17,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 
 @Configuration
 @RequiredArgsConstructor
+@EnableJpaAuditing
 public class WebConfig implements WebMvcConfigurer {
 
     private final JwtTokenUtil jwtTokenUtil;

--- a/src/main/java/com/project/policy/application/PolicyService.java
+++ b/src/main/java/com/project/policy/application/PolicyService.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.policy.application.dto.FamilyPolicyDto;
 import com.project.policy.application.repository.PolicyCommandRepository;
 import com.project.policy.application.repository.PolicyQueryRepository;

--- a/src/main/java/com/project/policy/application/PolicyService.java
+++ b/src/main/java/com/project/policy/application/PolicyService.java
@@ -37,7 +37,6 @@ public class PolicyService {
     /** 특정 멤버의 특정 타입 정책 수정 */
     @Transactional
     public void updateMemberPolicy(
-            Long ignoredFamilyId,
             Long targetCustomerId,
             PolicyType type,
             String newRules,

--- a/src/main/java/com/project/policy/application/PolicyService.java
+++ b/src/main/java/com/project/policy/application/PolicyService.java
@@ -1,0 +1,62 @@
+package com.project.policy.application;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.policy.application.dto.FamilyPolicyDto;
+import com.project.policy.application.repository.PolicyCommandRepository;
+import com.project.policy.application.repository.PolicyQueryRepository;
+import com.project.policy.core.PolicyAssignment;
+import com.project.policy.core.PolicyType;
+import com.project.policy.web.dto.response.FamilyPolicyResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PolicyService {
+
+    private final PolicyCommandRepository policyCommandRepository;
+    private final PolicyQueryRepository policyQueryRepository;
+    private final ObjectMapper objectMapper;
+
+    /** customerId가 속한 가족의 모든 정책 조회 */
+    @Transactional(readOnly = true)
+    public FamilyPolicyResponse getFamilyPolicyResponse(Long customerId) {
+
+        // QueryDSL로 데이터 조회
+        List<FamilyPolicyDto> flatList =
+                policyQueryRepository.findAllFamilyPoliciesByCustomerId(customerId);
+        // 응답 조립
+        return FamilyPolicyResponse.from(flatList);
+    }
+
+    /** 특정 멤버의 특정 타입 정책 수정 */
+    @Transactional
+    public void updateMemberPolicy(
+            Long ignoredFamilyId,
+            Long targetCustomerId,
+            PolicyType type,
+            String newRules,
+            Boolean isActive,
+            Long actorId) {
+        Long familyId =
+                policyQueryRepository
+                        .findFamilyIdByTargetCustomerId(actorId)
+                        .orElseThrow(() -> new IllegalArgumentException("가족 정보를 찾을 수 없습니다."));
+        PolicyAssignment assignment =
+                policyQueryRepository
+                        .findByTargetAndType(familyId, targetCustomerId, type)
+                        .orElseThrow(() -> new IllegalArgumentException("해당 정책이 존재하지 않습니다."));
+        if (newRules != null) {
+            assignment.updateRules(newRules);
+        }
+        if (isActive != null) {
+            assignment.toggleActive(isActive, actorId);
+        }
+        policyCommandRepository.save(assignment);
+    }
+}

--- a/src/main/java/com/project/policy/application/PolicyService.java
+++ b/src/main/java/com/project/policy/application/PolicyService.java
@@ -2,6 +2,7 @@ package com.project.policy.application;
 
 import java.util.List;
 
+import com.project.customer.core.Role;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,8 +44,8 @@ public class PolicyService {
             Long actorId) {
 
         // 1. 요청자(Actor) 권한 검증
-        com.project.customer.core.Role actorRole = jpaFamilyMemberRepository.findRoleById(actorId);
-        if (actorRole != com.project.customer.core.Role.OWNER) {
+        Role actorRole = jpaFamilyMemberRepository.findRoleById(actorId);
+        if (actorRole != Role.OWNER) {
             throw new IllegalArgumentException("가족장만 접근 가능합니다.");
         }
 

--- a/src/main/java/com/project/policy/application/PolicyService.java
+++ b/src/main/java/com/project/policy/application/PolicyService.java
@@ -20,11 +20,12 @@ public class PolicyService {
 
     private final PolicyCommandRepository policyCommandRepository;
     private final PolicyQueryRepository policyQueryRepository;
+    private final com.project.family.infra.repository.JpaFamilyMemberRepository
+            jpaFamilyMemberRepository;
 
     /** customerId가 속한 가족의 모든 정책 조회 */
     @Transactional(readOnly = true)
     public FamilyPolicyResponse getFamilyPolicyResponse(Long customerId) {
-
         // QueryDSL로 데이터 조회
         List<FamilyPolicyDto> flatList =
                 policyQueryRepository.findAllFamilyPoliciesByCustomerId(customerId);
@@ -40,6 +41,13 @@ public class PolicyService {
             String newRules,
             Boolean isActive,
             Long actorId) {
+
+        // 1. 요청자(Actor) 권한 검증
+        com.project.customer.core.Role actorRole = jpaFamilyMemberRepository.findRoleById(actorId);
+        if (actorRole != com.project.customer.core.Role.OWNER) {
+            throw new IllegalArgumentException("가족장만 접근 가능합니다.");
+        }
+
         Long familyId =
                 policyQueryRepository
                         .findFamilyIdByTargetCustomerId(actorId)

--- a/src/main/java/com/project/policy/application/PolicyService.java
+++ b/src/main/java/com/project/policy/application/PolicyService.java
@@ -2,10 +2,10 @@ package com.project.policy.application;
 
 import java.util.List;
 
-import com.project.customer.core.Role;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.project.customer.core.Role;
 import com.project.policy.application.dto.FamilyPolicyDto;
 import com.project.policy.application.repository.PolicyCommandRepository;
 import com.project.policy.application.repository.PolicyQueryRepository;

--- a/src/main/java/com/project/policy/application/PolicyService.java
+++ b/src/main/java/com/project/policy/application/PolicyService.java
@@ -21,7 +21,6 @@ public class PolicyService {
 
     private final PolicyCommandRepository policyCommandRepository;
     private final PolicyQueryRepository policyQueryRepository;
-    private final ObjectMapper objectMapper;
 
     /** customerId가 속한 가족의 모든 정책 조회 */
     @Transactional(readOnly = true)

--- a/src/main/java/com/project/policy/application/PolicyService.java
+++ b/src/main/java/com/project/policy/application/PolicyService.java
@@ -50,12 +50,9 @@ public class PolicyService {
                 policyQueryRepository
                         .findByTargetAndType(familyId, targetCustomerId, type)
                         .orElseThrow(() -> new IllegalArgumentException("해당 정책이 존재하지 않습니다."));
-        if (newRules != null) {
-            assignment.updateRules(newRules);
-        }
-        if (isActive != null) {
-            assignment.toggleActive(isActive, actorId);
-        }
+
+        assignment.update(newRules, isActive, actorId);
+
         policyCommandRepository.save(assignment);
     }
 }

--- a/src/main/java/com/project/policy/application/dto/FamilyPolicyDto.java
+++ b/src/main/java/com/project/policy/application/dto/FamilyPolicyDto.java
@@ -3,49 +3,18 @@ package com.project.policy.application.dto;
 import com.project.policy.core.PolicyType;
 import com.querydsl.core.annotations.QueryProjection;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Getter
-@NoArgsConstructor
-public class FamilyPolicyDto {
-    private Long familyId;
-    private Long customerId;
-    private String customerName;
-    private String phoneNumber;
-    private String role; // FamilyMemberRole
-
-    // PolicyAssignment
-    private Long assignmentId;
-    private Long policyId;
-    private String policyName;
-    private PolicyType type;
-    private boolean isActive;
-    private String rules;
-
+public record FamilyPolicyDto(
+        Long familyId,
+        Long customerId,
+        String customerName,
+        String phoneNumber,
+        String role,
+        Long assignmentId,
+        Long policyId,
+        String policyName,
+        PolicyType type,
+        boolean isActive,
+        String rules) {
     @QueryProjection
-    public FamilyPolicyDto(
-            Long familyId,
-            Long customerId,
-            String customerName,
-            String phoneNumber,
-            String role,
-            Long assignmentId,
-            Long policyId,
-            String policyName,
-            PolicyType type,
-            boolean isActive,
-            String rules) {
-        this.familyId = familyId;
-        this.customerId = customerId;
-        this.customerName = customerName;
-        this.phoneNumber = phoneNumber;
-        this.role = role;
-        this.assignmentId = assignmentId;
-        this.policyId = policyId;
-        this.policyName = policyName;
-        this.type = type;
-        this.isActive = isActive;
-        this.rules = rules;
-    }
+    public FamilyPolicyDto {}
 }

--- a/src/main/java/com/project/policy/application/dto/FamilyPolicyDto.java
+++ b/src/main/java/com/project/policy/application/dto/FamilyPolicyDto.java
@@ -1,0 +1,51 @@
+package com.project.policy.application.dto;
+
+import com.project.policy.core.PolicyType;
+import com.querydsl.core.annotations.QueryProjection;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FamilyPolicyDto {
+    private Long familyId;
+    private Long customerId;
+    private String customerName;
+    private String phoneNumber;
+    private String role; // FamilyMemberRole
+
+    // PolicyAssignment
+    private Long assignmentId;
+    private Long policyId;
+    private String policyName;
+    private PolicyType type;
+    private boolean isActive;
+    private String rules;
+
+    @QueryProjection
+    public FamilyPolicyDto(
+            Long familyId,
+            Long customerId,
+            String customerName,
+            String phoneNumber,
+            String role,
+            Long assignmentId,
+            Long policyId,
+            String policyName,
+            PolicyType type,
+            boolean isActive,
+            String rules) {
+        this.familyId = familyId;
+        this.customerId = customerId;
+        this.customerName = customerName;
+        this.phoneNumber = phoneNumber;
+        this.role = role;
+        this.assignmentId = assignmentId;
+        this.policyId = policyId;
+        this.policyName = policyName;
+        this.type = type;
+        this.isActive = isActive;
+        this.rules = rules;
+    }
+}

--- a/src/main/java/com/project/policy/application/repository/PolicyCommandRepository.java
+++ b/src/main/java/com/project/policy/application/repository/PolicyCommandRepository.java
@@ -1,0 +1,7 @@
+package com.project.policy.application.repository;
+
+import com.project.policy.core.PolicyAssignment;
+
+public interface PolicyCommandRepository {
+    PolicyAssignment save(PolicyAssignment policyAssignment);
+}

--- a/src/main/java/com/project/policy/application/repository/PolicyQueryRepository.java
+++ b/src/main/java/com/project/policy/application/repository/PolicyQueryRepository.java
@@ -1,0 +1,17 @@
+package com.project.policy.application.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.project.policy.application.dto.FamilyPolicyDto;
+import com.project.policy.core.PolicyAssignment;
+import com.project.policy.core.PolicyType;
+
+public interface PolicyQueryRepository {
+    List<FamilyPolicyDto> findAllFamilyPoliciesByCustomerId(Long customerId);
+
+    Optional<PolicyAssignment> findByTargetAndType(
+            Long familyId, Long targetCustomerId, PolicyType type);
+
+    Optional<Long> findFamilyIdByTargetCustomerId(Long customerId);
+}

--- a/src/main/java/com/project/policy/core/Policy.java
+++ b/src/main/java/com/project/policy/core/Policy.java
@@ -1,0 +1,29 @@
+package com.project.policy.core;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class Policy {
+    private Long id;
+    private String name;
+    private String description;
+    private RequireRole requireRole;
+    private PolicyType type;
+    private String defaultRules;
+    private boolean isSystem;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
+
+    public boolean isActive() {
+        return deletedAt == null;
+    }
+
+    public boolean isModifiable() {
+        return !isSystem && isActive();
+    }
+}

--- a/src/main/java/com/project/policy/core/PolicyAssignment.java
+++ b/src/main/java/com/project/policy/core/PolicyAssignment.java
@@ -29,4 +29,18 @@ public class PolicyAssignment {
         }
         this.isActive = active;
     }
+
+    public void update(String newRules, Boolean isActive, Long actorId) {
+        if (newRules != null) {
+            this.rules = newRules;
+        }
+        if (isActive != null) {
+            boolean newActiveState = isActive;
+            if (newActiveState && !this.isActive) {
+                this.appliedAt = LocalDateTime.now();
+                this.appliedById = actorId;
+            }
+            this.isActive = newActiveState;
+        }
+    }
 }

--- a/src/main/java/com/project/policy/core/PolicyAssignment.java
+++ b/src/main/java/com/project/policy/core/PolicyAssignment.java
@@ -1,0 +1,32 @@
+package com.project.policy.core;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PolicyAssignment {
+    private Long id;
+    private Long policyId;
+    private Long familyId;
+    private Long targetCustomerId;
+    private String rules;
+    private boolean isActive;
+    private LocalDateTime appliedAt;
+    private Long appliedById;
+    private LocalDateTime deletedAt;
+
+    public void updateRules(String newRules) {
+        this.rules = newRules;
+    }
+
+    public void toggleActive(boolean active, Long actorId) {
+        if (active && !this.isActive) {
+            this.appliedAt = LocalDateTime.now();
+            this.appliedById = actorId;
+        }
+        this.isActive = active;
+    }
+}

--- a/src/main/java/com/project/policy/core/PolicyAssignment.java
+++ b/src/main/java/com/project/policy/core/PolicyAssignment.java
@@ -31,4 +31,5 @@ public class PolicyAssignment {
                 this.appliedById = actorId;
             }
         }
+    }
 }

--- a/src/main/java/com/project/policy/core/PolicyAssignment.java
+++ b/src/main/java/com/project/policy/core/PolicyAssignment.java
@@ -18,29 +18,17 @@ public class PolicyAssignment {
     private Long appliedById;
     private LocalDateTime deletedAt;
 
-    public void updateRules(String newRules) {
-        this.rules = newRules;
-    }
-
-    public void toggleActive(boolean active, Long actorId) {
-        if (active && !this.isActive) {
-            this.appliedAt = LocalDateTime.now();
-            this.appliedById = actorId;
-        }
-        this.isActive = active;
-    }
-
     public void update(String newRules, Boolean isActive, Long actorId) {
         if (newRules != null) {
             this.rules = newRules;
         }
         if (isActive != null) {
-            boolean newActiveState = isActive;
-            if (newActiveState && !this.isActive) {
+            boolean previousActiveState = this.isActive;
+            this.isActive = isActive;
+
+            if (isActive && !previousActiveState) {
                 this.appliedAt = LocalDateTime.now();
                 this.appliedById = actorId;
             }
-            this.isActive = newActiveState;
         }
-    }
 }

--- a/src/main/java/com/project/policy/core/PolicyType.java
+++ b/src/main/java/com/project/policy/core/PolicyType.java
@@ -1,0 +1,9 @@
+package com.project.policy.core;
+
+public enum PolicyType {
+    MONTHLY_LIMIT,
+    TIME_BLOCK,
+    MANUAL_BLOCK,
+    APP_BLOCK,
+    WEBSITE_BLOCK
+}

--- a/src/main/java/com/project/policy/core/PolicyUpdateStatus.java
+++ b/src/main/java/com/project/policy/core/PolicyUpdateStatus.java
@@ -1,0 +1,5 @@
+package com.project.policy.core;
+
+public enum PolicyUpdateStatus {
+    APPLIED
+}

--- a/src/main/java/com/project/policy/core/RequireRole.java
+++ b/src/main/java/com/project/policy/core/RequireRole.java
@@ -1,0 +1,7 @@
+package com.project.policy.core;
+
+public enum RequireRole {
+    MEMBER,
+    OWNER,
+    ADMIN
+}

--- a/src/main/java/com/project/policy/infra/entity/PolicyAssignmentJpaEntity.java
+++ b/src/main/java/com/project/policy/infra/entity/PolicyAssignmentJpaEntity.java
@@ -1,0 +1,50 @@
+package com.project.policy.infra.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import com.project.customer.infra.entity.BaseJpaEntity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "policy_assignment")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PolicyAssignmentJpaEntity extends BaseJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long policyId;
+
+    @Column(nullable = false)
+    private Long familyId;
+
+    @Column(name = "target_customer_id")
+    private Long targetCustomerId;
+
+    // JSON 타입은 문자열로 저장
+    @Column(columnDefinition = "json", nullable = false)
+    private String rules;
+
+    @Column(nullable = false)
+    private boolean isActive;
+
+    private LocalDateTime appliedAt;
+
+    private Long appliedById;
+}

--- a/src/main/java/com/project/policy/infra/entity/PolicyJpaEntity.java
+++ b/src/main/java/com/project/policy/infra/entity/PolicyJpaEntity.java
@@ -1,0 +1,52 @@
+package com.project.policy.infra.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import com.project.customer.infra.entity.BaseJpaEntity;
+import com.project.policy.core.PolicyType;
+import com.project.policy.core.RequireRole;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "policy")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PolicyJpaEntity extends BaseJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "require_role", nullable = false)
+    private RequireRole requireRole;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PolicyType type;
+
+    @Column(name = "default_rules", columnDefinition = "json", nullable = false)
+    private String defaultRules;
+
+    @Column(name = "is_system", columnDefinition = "tinyint", nullable = false)
+    private boolean isSystem;
+}

--- a/src/main/java/com/project/policy/infra/mapper/PolicyAssignmentEntityMapper.java
+++ b/src/main/java/com/project/policy/infra/mapper/PolicyAssignmentEntityMapper.java
@@ -1,0 +1,36 @@
+package com.project.policy.infra.mapper;
+
+import org.springframework.stereotype.Component;
+
+import com.project.policy.core.PolicyAssignment;
+import com.project.policy.infra.entity.PolicyAssignmentJpaEntity;
+
+@Component
+public class PolicyAssignmentEntityMapper {
+
+    public PolicyAssignmentJpaEntity toEntity(PolicyAssignment domain) {
+        return PolicyAssignmentJpaEntity.builder()
+                .id(domain.getId())
+                .policyId(domain.getPolicyId())
+                .familyId(domain.getFamilyId())
+                .targetCustomerId(domain.getTargetCustomerId())
+                .rules(domain.getRules())
+                .isActive(domain.isActive())
+                .appliedAt(domain.getAppliedAt())
+                .appliedById(domain.getAppliedById())
+                .build();
+    }
+
+    public PolicyAssignment toDomain(PolicyAssignmentJpaEntity entity) {
+        return PolicyAssignment.builder()
+                .id(entity.getId())
+                .policyId(entity.getPolicyId())
+                .familyId(entity.getFamilyId())
+                .targetCustomerId(entity.getTargetCustomerId())
+                .rules(entity.getRules())
+                .isActive(entity.isActive())
+                .appliedAt(entity.getAppliedAt())
+                .appliedById(entity.getAppliedById())
+                .build();
+    }
+}

--- a/src/main/java/com/project/policy/infra/mapper/PolicyEntityMapper.java
+++ b/src/main/java/com/project/policy/infra/mapper/PolicyEntityMapper.java
@@ -1,0 +1,37 @@
+package com.project.policy.infra.mapper;
+
+import org.springframework.stereotype.Component;
+
+import com.project.policy.core.Policy;
+import com.project.policy.infra.entity.PolicyJpaEntity;
+
+@Component
+public class PolicyEntityMapper {
+
+    public PolicyJpaEntity toEntity(Policy domain) {
+        return PolicyJpaEntity.builder()
+                .id(domain.getId())
+                .name(domain.getName())
+                .description(domain.getDescription())
+                .requireRole(domain.getRequireRole())
+                .type(domain.getType())
+                .defaultRules(domain.getDefaultRules())
+                .isSystem(domain.isSystem())
+                .build();
+    }
+
+    public Policy toDomain(PolicyJpaEntity entity) {
+        return Policy.builder()
+                .id(entity.getId())
+                .name(entity.getName())
+                .description(entity.getDescription())
+                .requireRole(entity.getRequireRole())
+                .type(entity.getType())
+                .defaultRules(entity.getDefaultRules())
+                .isSystem(entity.isSystem())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .deletedAt(entity.getDeletedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/project/policy/infra/repository/PolicyAssignmentJpaRepository.java
+++ b/src/main/java/com/project/policy/infra/repository/PolicyAssignmentJpaRepository.java
@@ -1,0 +1,31 @@
+package com.project.policy.infra.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.project.policy.core.PolicyType;
+import com.project.policy.infra.entity.PolicyAssignmentJpaEntity;
+
+public interface PolicyAssignmentJpaRepository
+        extends JpaRepository<PolicyAssignmentJpaEntity, Long> {
+    @Query(
+            "SELECT p FROM PolicyAssignmentJpaEntity p WHERE p.familyId = :familyId AND p.deletedAt"
+                    + " IS NULL")
+    List<PolicyAssignmentJpaEntity> findAllByFamilyId(@Param("familyId") Long familyId);
+
+    @Query(
+            "SELECT pa FROM PolicyAssignmentJpaEntity pa "
+                    + "JOIN PolicyJpaEntity p ON pa.policyId = p.id "
+                    + "WHERE pa.familyId = :familyId "
+                    + "AND pa.targetCustomerId = :targetCustomerId "
+                    + "AND p.type = :type "
+                    + "AND pa.deletedAt IS NULL")
+    Optional<PolicyAssignmentJpaEntity> findByTargetAndType(
+            @Param("familyId") Long familyId,
+            @Param("targetCustomerId") Long targetCustomerId,
+            @Param("type") PolicyType type);
+}

--- a/src/main/java/com/project/policy/infra/repository/PolicyCommandRepositoryImpl.java
+++ b/src/main/java/com/project/policy/infra/repository/PolicyCommandRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.project.policy.infra.repository;
+
+import org.springframework.stereotype.Repository;
+
+import com.project.policy.application.repository.PolicyCommandRepository;
+import com.project.policy.core.PolicyAssignment;
+import com.project.policy.infra.entity.PolicyAssignmentJpaEntity;
+import com.project.policy.infra.mapper.PolicyAssignmentEntityMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class PolicyCommandRepositoryImpl implements PolicyCommandRepository {
+    private final PolicyAssignmentJpaRepository jpaRepository;
+    private final PolicyAssignmentEntityMapper mapper;
+
+    // --- Command (쓰기) ---
+    @Override
+    public PolicyAssignment save(PolicyAssignment domain) {
+        PolicyAssignmentJpaEntity entity = mapper.toEntity(domain);
+        return mapper.toDomain(jpaRepository.save(entity));
+    }
+}

--- a/src/main/java/com/project/policy/infra/repository/PolicyJpaRepository.java
+++ b/src/main/java/com/project/policy/infra/repository/PolicyJpaRepository.java
@@ -1,0 +1,7 @@
+package com.project.policy.infra.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.project.policy.infra.entity.PolicyJpaEntity;
+
+public interface PolicyJpaRepository extends JpaRepository<PolicyJpaEntity, Long> {}

--- a/src/main/java/com/project/policy/infra/repository/PolicyQueryRepositoryImpl.java
+++ b/src/main/java/com/project/policy/infra/repository/PolicyQueryRepositoryImpl.java
@@ -1,0 +1,120 @@
+package com.project.policy.infra.repository;
+
+import static com.project.family.infra.entity.QFamilyMemberJpaEntity.familyMemberJpaEntity;
+import static com.project.policy.infra.entity.QPolicyJpaEntity.policyJpaEntity;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.project.customer.infra.entity.QCustomerJpaEntity;
+import com.project.family.infra.entity.QFamilyMemberJpaEntity;
+import com.project.policy.application.dto.FamilyPolicyDto;
+import com.project.policy.application.dto.QFamilyPolicyDto;
+import com.project.policy.application.repository.PolicyQueryRepository;
+import com.project.policy.core.PolicyAssignment;
+import com.project.policy.core.PolicyType;
+import com.project.policy.infra.entity.QPolicyAssignmentJpaEntity;
+import com.project.policy.infra.entity.QPolicyJpaEntity;
+import com.project.policy.infra.mapper.PolicyAssignmentEntityMapper;
+import com.project.policy.infra.mapper.PolicyEntityMapper;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class PolicyQueryRepositoryImpl implements PolicyQueryRepository {
+
+    private final PolicyAssignmentJpaRepository assignmentJpaRepository;
+    private final PolicyJpaRepository policyJpaRepository;
+
+    private final PolicyAssignmentEntityMapper assignmentMapper;
+    private final PolicyEntityMapper policyMapper;
+
+    private final JPAQueryFactory queryFactory;
+
+    // --- Query (읽기) ---
+
+    @Override
+    public Optional<PolicyAssignment> findByTargetAndType(
+            Long familyId, Long targetCustomerId, PolicyType type) {
+        return assignmentJpaRepository
+                .findByTargetAndType(familyId, targetCustomerId, type)
+                .map(assignmentMapper::toDomain);
+    }
+
+    @Override
+    public List<FamilyPolicyDto> findAllFamilyPoliciesByCustomerId(Long customerId) {
+        QFamilyMemberJpaEntity member = familyMemberJpaEntity;
+        QCustomerJpaEntity customer = QCustomerJpaEntity.customerJpaEntity;
+        QPolicyAssignmentJpaEntity assignment =
+                QPolicyAssignmentJpaEntity.policyAssignmentJpaEntity;
+        QPolicyJpaEntity policy = policyJpaEntity;
+
+        // 서브쿼리용 별칭
+        QFamilyMemberJpaEntity subMember = new QFamilyMemberJpaEntity("subMember");
+        return queryFactory
+                .select(
+                        new QFamilyPolicyDto(
+                                member.familyId,
+                                member.customerId,
+                                customer.name,
+                                customer.phoneNumber,
+                                member.role.stringValue(),
+                                assignment.id,
+                                policy.id,
+                                policy.name,
+                                policy.type,
+                                assignment.isActive,
+                                assignment.rules))
+                .from(member)
+                .join(customer)
+                .on(member.customerId.eq(customer.id))
+                .leftJoin(assignment)
+                .on(
+                        assignment
+                                .familyId
+                                .eq(member.familyId)
+                                .and(assignment.deletedAt.isNull())
+                                .and(
+                                        assignment
+                                                .targetCustomerId
+                                                .eq(member.customerId)
+                                                .or(assignment.targetCustomerId.isNull())))
+                .leftJoin(policy)
+                .on(assignment.policyId.eq(policy.id))
+
+                // 내 가족 ID와 같은 멤버들 조회 (SubQuery)
+                .where(
+                        member.familyId
+                                .eq(
+                                        JPAExpressions.select(subMember.familyId)
+                                                .from(subMember)
+                                                .where(
+                                                        subMember
+                                                                .customerId
+                                                                .eq(customerId)
+                                                                .and(subMember.deletedAt.isNull())))
+                                .and(member.deletedAt.isNull()))
+                .orderBy(member.customerId.asc(), assignment.id.asc())
+                .fetch();
+    }
+
+    @Override
+    public Optional<Long> findFamilyIdByTargetCustomerId(Long customerId) {
+        Long familyId =
+                queryFactory
+                        .select(familyMemberJpaEntity.familyId)
+                        .from(familyMemberJpaEntity)
+                        .where(
+                                familyMemberJpaEntity
+                                        .customerId
+                                        .eq(customerId)
+                                        .and(familyMemberJpaEntity.deletedAt.isNull()))
+                        .fetchOne();
+        return Optional.ofNullable(familyId);
+    }
+}

--- a/src/main/java/com/project/policy/web/FamilyPolicyController.java
+++ b/src/main/java/com/project/policy/web/FamilyPolicyController.java
@@ -49,7 +49,6 @@ public class FamilyPolicyController {
                 : null;
 
         policyService.updateMemberPolicy(
-                null,
                 updateInfo.customerId(),
                 updateInfo.type(),
                 rulesJson,

--- a/src/main/java/com/project/policy/web/FamilyPolicyController.java
+++ b/src/main/java/com/project/policy/web/FamilyPolicyController.java
@@ -26,27 +26,24 @@ public class FamilyPolicyController {
     private final PolicyService policyService;
     private final ObjectMapper objectMapper;
 
-    /**
-     * 가족 구성원에게 적용되고 있는 정책 목록 조회
-     */
+    /** 가족 구성원에게 적용되고 있는 정책 목록 조회 */
     @GetMapping
     public ApiResponse<FamilyPolicyResponse> getFamilyPolicies(@CustomerId Long customerId) {
         FamilyPolicyResponse response = policyService.getFamilyPolicyResponse(customerId);
         return ApiResponse.success(response);
     }
 
-    /**
-     * 가족 구성원의 정책 부분 수정
-     */
+    /** 가족 구성원의 정책 부분 수정 */
     @PatchMapping
     public ApiResponse<PolicyUpdateResponse> updatePolicy(
             @CustomerId Long actorId, @RequestBody @Valid PolicyUpdateRequest request)
             throws JsonProcessingException {
 
         var updateInfo = request.update();
-        String rulesJson = (updateInfo.rules() != null)
-                ? objectMapper.writeValueAsString(updateInfo.rules())
-                : null;
+        String rulesJson =
+                (updateInfo.rules() != null)
+                        ? objectMapper.writeValueAsString(updateInfo.rules())
+                        : null;
 
         policyService.updateMemberPolicy(
                 updateInfo.customerId(),

--- a/src/main/java/com/project/policy/web/FamilyPolicyController.java
+++ b/src/main/java/com/project/policy/web/FamilyPolicyController.java
@@ -1,0 +1,62 @@
+package com.project.policy.web;
+
+import jakarta.validation.Valid;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.customer.web.aop.CustomerId;
+import com.project.global.api.response.ApiResponse;
+import com.project.policy.application.PolicyService;
+import com.project.policy.web.dto.request.PolicyUpdateRequest;
+import com.project.policy.web.dto.response.FamilyPolicyResponse;
+import com.project.policy.web.dto.response.PolicyUpdateResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/families/policies")
+@RequiredArgsConstructor
+public class FamilyPolicyController {
+    private final PolicyService policyService;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 가족 구성원에게 적용되고 있는 정책 목록 조회
+     */
+    @GetMapping
+    public ApiResponse<FamilyPolicyResponse> getFamilyPolicies(@CustomerId Long customerId) {
+        FamilyPolicyResponse response = policyService.getFamilyPolicyResponse(customerId);
+        return ApiResponse.success(response);
+    }
+
+    /**
+     * 가족 구성원의 정책 부분 수정
+     */
+    @PatchMapping
+    public ApiResponse<PolicyUpdateResponse> updatePolicy(
+            @CustomerId Long actorId, @RequestBody @Valid PolicyUpdateRequest request)
+            throws JsonProcessingException {
+
+        var updateInfo = request.update();
+        String rulesJson = (updateInfo.rules() != null)
+                ? objectMapper.writeValueAsString(updateInfo.rules())
+                : null;
+
+        policyService.updateMemberPolicy(
+                null,
+                updateInfo.customerId(),
+                updateInfo.type(),
+                rulesJson,
+                updateInfo.isActive(),
+                actorId);
+
+        return ApiResponse.success(
+                PolicyUpdateResponse.success(updateInfo.customerId(), updateInfo.type()));
+    }
+}

--- a/src/main/java/com/project/policy/web/dto/request/PolicyUpdateRequest.java
+++ b/src/main/java/com/project/policy/web/dto/request/PolicyUpdateRequest.java
@@ -1,0 +1,21 @@
+package com.project.policy.web.dto.request;
+
+import java.util.Map;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.project.policy.core.PolicyType;
+
+public record PolicyUpdateRequest(@Valid @NotNull UpdateInfo update) {
+    public record UpdateInfo(
+            @NotNull Long customerId,
+            @NotNull PolicyType type,
+
+            // Nullable (규칙 수정 시에만 보냄)
+            @JsonProperty("value") Map<String, Object> rules,
+
+            // Nullable (활성 상태 변경 시에만 보냄)
+            Boolean isActive) {}
+}

--- a/src/main/java/com/project/policy/web/dto/response/FamilyPolicyResponse.java
+++ b/src/main/java/com/project/policy/web/dto/response/FamilyPolicyResponse.java
@@ -9,16 +9,15 @@ import com.project.policy.application.dto.FamilyPolicyDto;
 import com.project.policy.core.PolicyType;
 
 public record FamilyPolicyResponse(Long familyId, List<CustomerInfo> customers) {
-    // Flat DTO -> 계층형 응답 변환 팩토리 메서드
     public static FamilyPolicyResponse from(List<FamilyPolicyDto> dtos) {
         if (dtos == null || dtos.isEmpty()) {
             return new FamilyPolicyResponse(null, List.of());
         }
 
-        Long familyId = dtos.get(0).getFamilyId();
+        Long familyId = dtos.get(0).familyId();
 
         Map<Long, List<FamilyPolicyDto>> grouped =
-                dtos.stream().collect(Collectors.groupingBy(FamilyPolicyDto::getCustomerId));
+                dtos.stream().collect(Collectors.groupingBy(FamilyPolicyDto::customerId));
 
         List<CustomerInfo> customerInfos =
                 grouped.values().stream()
@@ -28,16 +27,16 @@ public record FamilyPolicyResponse(Long familyId, List<CustomerInfo> customers) 
 
                                     List<PolicyInfo> policies =
                                             list.stream()
-                                                    .filter(dto -> dto.getAssignmentId() != null)
+                                                    .filter(dto -> dto.assignmentId() != null)
                                                     .map(PolicyInfo::from)
                                                     .toList();
 
                                     return new CustomerInfo(
-                                            first.getCustomerId(),
-                                            first.getCustomerName(),
-                                            first.getPhoneNumber(),
-                                            first.getRole(),
-                                            0L, // 사용량 정보
+                                            first.customerId(),
+                                            first.customerName(),
+                                            first.phoneNumber(),
+                                            first.role(),
+                                            0L,
                                             policies);
                                 })
                         .toList();
@@ -62,12 +61,12 @@ public record FamilyPolicyResponse(Long familyId, List<CustomerInfo> customers) 
             @JsonRawValue String rules) {
         public static PolicyInfo from(FamilyPolicyDto dto) {
             return new PolicyInfo(
-                    dto.getAssignmentId(),
-                    dto.getPolicyId(),
-                    dto.getPolicyName(),
-                    dto.getType(),
+                    dto.assignmentId(),
+                    dto.policyId(),
+                    dto.policyName(),
+                    dto.type(),
                     dto.isActive(),
-                    dto.getRules());
+                    dto.rules());
         }
     }
 }

--- a/src/main/java/com/project/policy/web/dto/response/FamilyPolicyResponse.java
+++ b/src/main/java/com/project/policy/web/dto/response/FamilyPolicyResponse.java
@@ -1,0 +1,73 @@
+package com.project.policy.web.dto.response;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonRawValue;
+import com.project.policy.application.dto.FamilyPolicyDto;
+import com.project.policy.core.PolicyType;
+
+public record FamilyPolicyResponse(Long familyId, List<CustomerInfo> customers) {
+    // Flat DTO -> 계층형 응답 변환 팩토리 메서드
+    public static FamilyPolicyResponse from(List<FamilyPolicyDto> dtos) {
+        if (dtos == null || dtos.isEmpty()) {
+            return new FamilyPolicyResponse(null, List.of());
+        }
+
+        Long familyId = dtos.get(0).getFamilyId();
+
+        Map<Long, List<FamilyPolicyDto>> grouped =
+                dtos.stream().collect(Collectors.groupingBy(FamilyPolicyDto::getCustomerId));
+
+        List<CustomerInfo> customerInfos =
+                grouped.values().stream()
+                        .map(
+                                list -> {
+                                    FamilyPolicyDto first = list.get(0);
+
+                                    List<PolicyInfo> policies =
+                                            list.stream()
+                                                    .filter(dto -> dto.getAssignmentId() != null)
+                                                    .map(PolicyInfo::from)
+                                                    .toList();
+
+                                    return new CustomerInfo(
+                                            first.getCustomerId(),
+                                            first.getCustomerName(),
+                                            first.getPhoneNumber(),
+                                            first.getRole(),
+                                            0L, // 사용량 정보
+                                            policies);
+                                })
+                        .toList();
+
+        return new FamilyPolicyResponse(familyId, customerInfos);
+    }
+
+    public record CustomerInfo(
+            Long customerId,
+            String name,
+            String phoneNumber,
+            String role,
+            Long usedBytes,
+            List<PolicyInfo> policies) {}
+
+    public record PolicyInfo(
+            Long assignmentId,
+            Long policyId,
+            String policyName,
+            PolicyType type,
+            boolean isActive,
+            @JsonRawValue String rules) {
+        public static PolicyInfo from(FamilyPolicyDto dto) {
+            return new PolicyInfo(
+                    dto.getAssignmentId(),
+                    dto.getPolicyId(),
+                    dto.getPolicyName(),
+                    dto.getType(),
+                    dto.isActive(),
+                    dto.getRules());
+        }
+    }
+}

--- a/src/main/java/com/project/policy/web/dto/response/PolicyUpdateResponse.java
+++ b/src/main/java/com/project/policy/web/dto/response/PolicyUpdateResponse.java
@@ -1,0 +1,11 @@
+package com.project.policy.web.dto.response;
+
+import com.project.policy.core.PolicyType;
+
+public record PolicyUpdateResponse(ResultInfo result) {
+    public static PolicyUpdateResponse success(Long userId, PolicyType type) {
+        return new PolicyUpdateResponse(new ResultInfo(userId, type, "APPLIED"));
+    }
+
+    public record ResultInfo(Long userId, PolicyType type, String status) {}
+}

--- a/src/main/java/com/project/policy/web/dto/response/PolicyUpdateResponse.java
+++ b/src/main/java/com/project/policy/web/dto/response/PolicyUpdateResponse.java
@@ -1,10 +1,13 @@
 package com.project.policy.web.dto.response;
 
 import com.project.policy.core.PolicyType;
+import com.project.policy.core.PolicyUpdateStatus;
 
 public record PolicyUpdateResponse(ResultInfo result) {
     public static PolicyUpdateResponse success(Long userId, PolicyType type) {
-        return new PolicyUpdateResponse(new ResultInfo(userId, type, "APPLIED"));
+        return new PolicyUpdateResponse(
+                new ResultInfo(userId, type, PolicyUpdateStatus.APPLIED.name())
+        );
     }
 
     public record ResultInfo(Long userId, PolicyType type, String status) {}

--- a/src/main/java/com/project/policy/web/dto/response/PolicyUpdateResponse.java
+++ b/src/main/java/com/project/policy/web/dto/response/PolicyUpdateResponse.java
@@ -6,8 +6,7 @@ import com.project.policy.core.PolicyUpdateStatus;
 public record PolicyUpdateResponse(ResultInfo result) {
     public static PolicyUpdateResponse success(Long userId, PolicyType type) {
         return new PolicyUpdateResponse(
-                new ResultInfo(userId, type, PolicyUpdateStatus.APPLIED.name())
-        );
+                new ResultInfo(userId, type, PolicyUpdateStatus.APPLIED.name()));
     }
 
     public record ResultInfo(Long userId, PolicyType type, String status) {}


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

- closed: #
- jira: DABOM-84

---

## 🎯 목적

가족 구성원에게 할당된 정책을 조회하고, 개별 멤버의 정책 설정(규칙, 활성 상태)을 수정하는 기능을 구현합니다. 또한 엔티티의 생성/수정/삭제 시간을 자동으로 관리하기 위해 JPA Auditing 설정을 적용했습니다.

## 📝 변경 사항

1. 시스템 전체 정책이 아닌 "가족 정책(Family Policy)" 관련 비즈니스 로직 및 API 구현 (조회, 수정) 
2. Policy 및 PolicyAssignment 도메인 엔티티 정의 및 JPA 매핑
3. BaseJpaEntity에 @CreatedDate, @LastModifiedDate를 적용하여 Auditing 활성화

-

## 📂 변경 범위

<!-- 변경된 도메인/레이어를 표시해주세요. 해당 항목에 [x]로 체크해주세요. -->

| 도메인 | web | application | core | infra |
| :----: | :-: | :---------: | :--: | :---: |
| policy | [x] |     [x]      | [x]   | [x]   |

---

## 🖥️ 주요 코드 설명

정책 수정 비즈니스 로직 (PolicyService.java) DB 조회 후 엔티티의 비즈니스 메소드(updateRules, toggleActive)를 호출하여 상태를 변경하도록 구현했습니다.

(가족 정책 관리(조회/수정) 기능 구현은 양이 많아서 생략)
```java
public void updateMemberPolicy(...) {
    // ... (가족 및 정책 할당 조회)
    // 규칙 변경 시
    if (newRules != null) {
        assignment.updateRules(newRules, actorId);
    }
    // 활성 상태 변경 시 (appliedAt 갱신 포함)
    if (isActive != null) {
        assignment.toggleActive(isActive, actorId);
    }
}
```

## 💬 리뷰어에게

- updated_at이 정상적으로 갱신되도록 WebConfig에 @EnableJpaAuditing을 추가했습니다.
- 정책 할당(policy_assignment) 테이블의 applied_at은 정책이 활성화(isActive=true)될 때만 갱신되도록 비즈니스 로직을 구성했습니다.

---

## 📋 체크리스트

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [ ] 전체 변경사항이 500줄을 넘지 않는가?

**코드 품질**
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [x] 비즈니스 로직이 Service가 아닌 Domain(core)에 있는가?
- [x] Setter 없이 비즈니스 메서드로 상태를 변경하는가?

**테스트**
- [ ] 신규 비즈니스 로직에 대한 단위 테스트를 작성했는가?
- [ ] 기존 테스트가 모두 통과하는가?

**아키텍처**
- [x] 의존성 방향을 준수하는가? (`Web → Application → Core ← Infra`)
- [x] core 패키지에 프레임워크 어노테이션(`@Entity`, `@Component` 등)이 없는가?
- [x] Repository가 Command/Query로 분리되어 있는가?

## 📌 참고 사항
