### PR TITLE
[DABOM-201] 가족 상세 조회 로직 개편

### DIFF
--- a/src/main/java/com/project/domain/customer/entity/CustomerQuota.java
+++ b/src/main/java/com/project/domain/customer/entity/CustomerQuota.java
@@ -8,10 +8,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 
 import com.project.global.util.BaseEntity;
 
-import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,9 +21,9 @@ import lombok.NoArgsConstructor;
 @Table(
         name = "customer_quota",
         uniqueConstraints = {
-                @UniqueConstraint(
-                        name = "uk_customer_quota_family_customer_month",
-                        columnNames = {"family_id", "customer_id", "current_month"})
+            @UniqueConstraint(
+                    name = "uk_customer_quota_family_customer_month",
+                    columnNames = {"family_id", "customer_id", "current_month"})
         })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/project/domain/customer/entity/CustomerQuota.java
+++ b/src/main/java/com/project/domain/customer/entity/CustomerQuota.java
@@ -11,13 +11,20 @@ import jakarta.persistence.Table;
 
 import com.project.global.util.BaseEntity;
 
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "customer_quota")
+@Table(
+        name = "customer_quota",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_customer_quota_family_customer_month",
+                        columnNames = {"family_id", "customer_id", "current_month"})
+        })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CustomerQuota extends BaseEntity {

--- a/src/main/java/com/project/domain/customer/entity/CustomerQuota.java
+++ b/src/main/java/com/project/domain/customer/entity/CustomerQuota.java
@@ -23,7 +23,7 @@ import lombok.NoArgsConstructor;
         uniqueConstraints = {
             @UniqueConstraint(
                     name = "uk_customer_quota_family_customer_month",
-                    columnNames = {"family_id", "customer_id", "current_month"})
+                    columnNames = {"family_id", "customer_id", "current_month", "deleted_at"})
         })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/project/domain/family/controller/FamilyController.java
+++ b/src/main/java/com/project/domain/family/controller/FamilyController.java
@@ -20,6 +20,7 @@ import com.project.domain.family.dto.response.FamilyDetailResponse;
 import com.project.domain.family.dto.response.FamilySearchResponse;
 import com.project.domain.family.dto.response.FamilyUsageReportResponse;
 import com.project.domain.family.model.FamilyDetail;
+import com.project.domain.family.model.FamilySearchResult;
 import com.project.domain.family.model.FamilyUsageReport;
 import com.project.domain.family.service.FamilyService;
 import com.project.domain.usagerecord.service.UsageRecordService;
@@ -47,7 +48,8 @@ public class FamilyController {
     @Operation(summary = "가족 목록 검색", description = "페이지, 필터, 검색 조건으로 가족 목록을 조회합니다.")
     public ApiResponse<Page<FamilySearchResponse>> searchFamilies(
             @RequestBody FamilySearchRequest familySearchRequest) {
-        Page<FamilySearchResponse> result = familyService.searchFamilies(familySearchRequest);
+        Page<FamilySearchResult> searchResult = familyService.searchFamilies(familySearchRequest);
+        Page<FamilySearchResponse> result = searchResult.map(FamilySearchResponse::from);
         return ApiResponse.success(result);
     }
 

--- a/src/main/java/com/project/domain/family/controller/FamilyController.java
+++ b/src/main/java/com/project/domain/family/controller/FamilyController.java
@@ -19,6 +19,7 @@ import com.project.domain.family.dto.request.FamilySearchRequest;
 import com.project.domain.family.dto.response.FamilyDetailResponse;
 import com.project.domain.family.dto.response.FamilySearchResponse;
 import com.project.domain.family.dto.response.FamilyUsageReportResponse;
+import com.project.domain.family.model.FamilyDetail;
 import com.project.domain.family.model.FamilyUsageReport;
 import com.project.domain.family.service.FamilyService;
 import com.project.domain.usagerecord.service.UsageRecordService;
@@ -55,8 +56,8 @@ public class FamilyController {
     @Operation(summary = "가족 상세 조회", description = "가족 ID로 가족 상세 정보를 조회합니다.")
     public ApiResponse<FamilyDetailResponse> getFamilyDetail(
             @Parameter(description = "가족 ID", required = true) @PathVariable Long familyId) {
-        FamilyDetailResponse result = familyService.getFamilyDetail(familyId);
-        return ApiResponse.success(result);
+        FamilyDetail familyDetail = familyService.getFamilyDetail(familyId);
+        return ApiResponse.success(FamilyDetailResponse.from(familyDetail));
     }
 
     @GetMapping(value = "/usage/current", produces = MediaType.TEXT_EVENT_STREAM_VALUE)

--- a/src/main/java/com/project/domain/family/dto/response/FamilyDetailResponse.java
+++ b/src/main/java/com/project/domain/family/dto/response/FamilyDetailResponse.java
@@ -4,6 +4,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.project.domain.family.model.FamilyDetail;
+
 public record FamilyDetailResponse(
         Long familyId,
         String familyName,
@@ -14,4 +16,21 @@ public record FamilyDetailResponse(
         double usedPercent,
         LocalDate currentMonth,
         LocalDateTime createdAt,
-        LocalDateTime updatedAt) {}
+        LocalDateTime updatedAt) {
+    public static FamilyDetailResponse from(FamilyDetail detail) {
+        List<FamilyMemberDetailResponse> customers =
+                detail.customers().stream().map(FamilyMemberDetailResponse::from).toList();
+
+        return new FamilyDetailResponse(
+                detail.familyId(),
+                detail.familyName(),
+                detail.createdById(),
+                customers,
+                detail.totalQuotaBytes(),
+                detail.usedBytes(),
+                detail.usedPercent(),
+                detail.currentMonth(),
+                detail.createdAt(),
+                detail.updatedAt());
+    }
+}

--- a/src/main/java/com/project/domain/family/dto/response/FamilyMemberDetailResponse.java
+++ b/src/main/java/com/project/domain/family/dto/response/FamilyMemberDetailResponse.java
@@ -1,10 +1,20 @@
 package com.project.domain.family.dto.response;
 
 import com.project.domain.customer.enums.RoleType;
+import com.project.domain.family.model.FamilyMemberDetail;
 
 public record FamilyMemberDetailResponse(
         Long customerId,
         String name,
         RoleType role,
         Long monthlyLimitBytes,
-        Long monthlyUsedBytes) {}
+        Long monthlyUsedBytes) {
+    public static FamilyMemberDetailResponse from(FamilyMemberDetail detail) {
+        return new FamilyMemberDetailResponse(
+                detail.customerId(),
+                detail.name(),
+                detail.role(),
+                detail.monthlyLimitBytes(),
+                detail.monthlyUsedBytes());
+    }
+}

--- a/src/main/java/com/project/domain/family/dto/response/FamilyMemberSimpleResponse.java
+++ b/src/main/java/com/project/domain/family/dto/response/FamilyMemberSimpleResponse.java
@@ -1,3 +1,9 @@
 package com.project.domain.family.dto.response;
 
-public record FamilyMemberSimpleResponse(Long customerId, String name) {}
+import com.project.domain.family.model.FamilyMemberSummary;
+
+public record FamilyMemberSimpleResponse(Long customerId, String name) {
+    public static FamilyMemberSimpleResponse from(FamilyMemberSummary summary) {
+        return new FamilyMemberSimpleResponse(summary.customerId(), summary.name());
+    }
+}

--- a/src/main/java/com/project/domain/family/dto/response/FamilySearchResponse.java
+++ b/src/main/java/com/project/domain/family/dto/response/FamilySearchResponse.java
@@ -3,8 +3,18 @@ package com.project.domain.family.dto.response;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.project.domain.family.model.FamilySearchResult;
+
 public record FamilySearchResponse(
         Long familyId,
         String familyName,
         List<FamilyMemberSimpleResponse> customers,
-        LocalDateTime createdAt) {}
+        LocalDateTime createdAt) {
+    public static FamilySearchResponse from(FamilySearchResult result) {
+        List<FamilyMemberSimpleResponse> customers =
+                result.customers().stream().map(FamilyMemberSimpleResponse::from).toList();
+
+        return new FamilySearchResponse(
+                result.familyId(), result.familyName(), customers, result.createdAt());
+    }
+}

--- a/src/main/java/com/project/domain/family/entity/Family.java
+++ b/src/main/java/com/project/domain/family/entity/Family.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
+import com.project.domain.family.util.FamilyUsageCalculator;
 import com.project.global.util.BaseEntity;
 
 import lombok.AccessLevel;
@@ -58,10 +59,7 @@ public class Family extends BaseEntity {
     }
 
     public double calculateUsedPercent() {
-        if (totalQuotaBytes == null || totalQuotaBytes == 0) {
-            return 0.0;
-        }
-        return (double) usedBytes / totalQuotaBytes * 100.0;
+        return FamilyUsageCalculator.calculateUsedPercent(usedBytes, totalQuotaBytes);
     }
 
     public void changeName(String name) {

--- a/src/main/java/com/project/domain/family/entity/Family.java
+++ b/src/main/java/com/project/domain/family/entity/Family.java
@@ -9,7 +9,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
-import com.project.domain.family.util.FamilyUsageCalculator;
 import com.project.global.util.BaseEntity;
 
 import lombok.AccessLevel;
@@ -56,10 +55,6 @@ public class Family extends BaseEntity {
         this.totalQuotaBytes = totalQuotaBytes;
         this.usedBytes = usedBytes;
         this.currentMonth = currentMonth;
-    }
-
-    public double calculateUsedPercent() {
-        return FamilyUsageCalculator.calculateUsedPercent(usedBytes, totalQuotaBytes);
     }
 
     public void changeName(String name) {

--- a/src/main/java/com/project/domain/family/model/FamilyDetail.java
+++ b/src/main/java/com/project/domain/family/model/FamilyDetail.java
@@ -1,0 +1,17 @@
+package com.project.domain.family.model;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record FamilyDetail(
+        Long familyId,
+        String familyName,
+        Long createdById,
+        List<FamilyMemberDetail> customers,
+        Long totalQuotaBytes,
+        Long usedBytes,
+        double usedPercent,
+        LocalDate currentMonth,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt) {}

--- a/src/main/java/com/project/domain/family/model/FamilyMemberDetail.java
+++ b/src/main/java/com/project/domain/family/model/FamilyMemberDetail.java
@@ -1,0 +1,10 @@
+package com.project.domain.family.model;
+
+import com.project.domain.customer.enums.RoleType;
+
+public record FamilyMemberDetail(
+        Long customerId,
+        String name,
+        RoleType role,
+        Long monthlyLimitBytes,
+        Long monthlyUsedBytes) {}

--- a/src/main/java/com/project/domain/family/model/FamilyMemberSummary.java
+++ b/src/main/java/com/project/domain/family/model/FamilyMemberSummary.java
@@ -1,0 +1,3 @@
+package com.project.domain.family.model;
+
+public record FamilyMemberSummary(Long customerId, String name) {}

--- a/src/main/java/com/project/domain/family/model/FamilySearchResult.java
+++ b/src/main/java/com/project/domain/family/model/FamilySearchResult.java
@@ -1,0 +1,10 @@
+package com.project.domain.family.model;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record FamilySearchResult(
+        Long familyId,
+        String familyName,
+        List<FamilyMemberSummary> customers,
+        LocalDateTime createdAt) {}

--- a/src/main/java/com/project/domain/family/repository/FamilyQueryRepository.java
+++ b/src/main/java/com/project/domain/family/repository/FamilyQueryRepository.java
@@ -25,6 +25,7 @@ import com.project.domain.family.model.FamilyMemberDetail;
 import com.project.domain.family.model.FamilyMemberSummary;
 import com.project.domain.family.model.FamilySearchResult;
 import com.project.domain.family.repository.projection.FamilyUsageCustomerRow;
+import com.project.domain.family.util.FamilyUsageCalculator;
 import com.project.global.exception.ApplicationException;
 import com.project.global.exception.code.FamilyErrorCode;
 import com.querydsl.core.Tuple;
@@ -136,11 +137,8 @@ public class FamilyQueryRepository {
                         .toList();
 
         double usedPercent =
-                familyEntity.getTotalQuotaBytes() > 0
-                        ? (double) familyEntity.getUsedBytes()
-                                / familyEntity.getTotalQuotaBytes()
-                                * 100.0
-                        : 0.0;
+                FamilyUsageCalculator.calculateUsedPercent(
+                        familyEntity.getUsedBytes(), familyEntity.getTotalQuotaBytes());
 
         return Optional.of(
                 new FamilyDetail(

--- a/src/main/java/com/project/domain/family/repository/FamilyQueryRepository.java
+++ b/src/main/java/com/project/domain/family/repository/FamilyQueryRepository.java
@@ -19,11 +19,11 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 import com.project.domain.family.dto.request.FamilySearchRequest;
-import com.project.domain.family.dto.response.FamilyDetailResponse;
-import com.project.domain.family.dto.response.FamilyMemberDetailResponse;
 import com.project.domain.family.dto.response.FamilyMemberSimpleResponse;
 import com.project.domain.family.dto.response.FamilySearchResponse;
 import com.project.domain.family.entity.Family;
+import com.project.domain.family.model.FamilyDetail;
+import com.project.domain.family.model.FamilyMemberDetail;
 import com.project.domain.family.repository.projection.FamilyUsageCustomerRow;
 import com.project.global.exception.ApplicationException;
 import com.project.global.exception.code.FamilyErrorCode;
@@ -90,7 +90,7 @@ public class FamilyQueryRepository {
         return new PageImpl<>(content, pageable, total);
     }
 
-    public Optional<FamilyDetailResponse> findDetailById(Long familyId) {
+    public Optional<FamilyDetail> findDetailById(Long familyId) {
         Family familyEntity =
                 queryFactory.selectFrom(family).where(family.id.eq(familyId)).fetchOne();
 
@@ -121,11 +121,11 @@ public class FamilyQueryRepository {
                         .where(familyMember.familyId.eq(familyId))
                         .fetch();
 
-        List<FamilyMemberDetailResponse> customers =
+        List<FamilyMemberDetail> customers =
                 results.stream()
                         .map(
                                 t ->
-                                        new FamilyMemberDetailResponse(
+                                        new FamilyMemberDetail(
                                                 t.get(customer.id),
                                                 t.get(customer.name),
                                                 t.get(familyMember.role),
@@ -143,7 +143,7 @@ public class FamilyQueryRepository {
                         : 0.0;
 
         return Optional.of(
-                new FamilyDetailResponse(
+                new FamilyDetail(
                         familyEntity.getId(),
                         familyEntity.getName(),
                         familyEntity.getCreatedById(),

--- a/src/main/java/com/project/domain/family/repository/FamilyQueryRepository.java
+++ b/src/main/java/com/project/domain/family/repository/FamilyQueryRepository.java
@@ -19,11 +19,11 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 import com.project.domain.family.dto.request.FamilySearchRequest;
-import com.project.domain.family.dto.response.FamilyMemberSimpleResponse;
-import com.project.domain.family.dto.response.FamilySearchResponse;
 import com.project.domain.family.entity.Family;
 import com.project.domain.family.model.FamilyDetail;
 import com.project.domain.family.model.FamilyMemberDetail;
+import com.project.domain.family.model.FamilyMemberSummary;
+import com.project.domain.family.model.FamilySearchResult;
 import com.project.domain.family.repository.projection.FamilyUsageCustomerRow;
 import com.project.global.exception.ApplicationException;
 import com.project.global.exception.code.FamilyErrorCode;
@@ -44,7 +44,7 @@ public class FamilyQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    public Page<FamilySearchResponse> search(FamilySearchRequest request) {
+    public Page<FamilySearchResult> search(FamilySearchRequest request) {
         PageRequest pageable = PageRequest.of(request.getPage(), request.getSize());
         FamilySearchRequest.Filters filters = request.filters();
 
@@ -73,13 +73,13 @@ public class FamilyQueryRepository {
         total = (total == null) ? 0L : total;
 
         List<Long> familyIds = families.stream().map(Family::getId).toList();
-        Map<Long, List<FamilyMemberSimpleResponse>> membersMap = fetchMembersMap(familyIds);
+        Map<Long, List<FamilyMemberSummary>> membersMap = fetchMembersMap(familyIds);
 
-        List<FamilySearchResponse> content =
+        List<FamilySearchResult> content =
                 families.stream()
                         .map(
                                 f ->
-                                        new FamilySearchResponse(
+                                        new FamilySearchResult(
                                                 f.getId(),
                                                 f.getName(),
                                                 membersMap.getOrDefault(
@@ -283,7 +283,7 @@ public class FamilyQueryRepository {
         };
     }
 
-    private Map<Long, List<FamilyMemberSimpleResponse>> fetchMembersMap(List<Long> familyIds) {
+    private Map<Long, List<FamilyMemberSummary>> fetchMembersMap(List<Long> familyIds) {
         if (familyIds.isEmpty()) {
             return Collections.emptyMap();
         }
@@ -306,7 +306,7 @@ public class FamilyQueryRepository {
                                                 "familyId must not be null"),
                                 Collectors.mapping(
                                         t ->
-                                                new FamilyMemberSimpleResponse(
+                                                new FamilyMemberSummary(
                                                         t.get(customer.id), t.get(customer.name)),
                                         Collectors.toList())));
     }

--- a/src/main/java/com/project/domain/family/service/FamilyService.java
+++ b/src/main/java/com/project/domain/family/service/FamilyService.java
@@ -3,12 +3,12 @@ package com.project.domain.family.service;
 import org.springframework.data.domain.Page;
 
 import com.project.domain.family.dto.request.FamilySearchRequest;
-import com.project.domain.family.dto.response.FamilySearchResponse;
 import com.project.domain.family.model.FamilyDetail;
+import com.project.domain.family.model.FamilySearchResult;
 import com.project.domain.family.model.FamilyUsageReport;
 
 public interface FamilyService {
-    Page<FamilySearchResponse> searchFamilies(FamilySearchRequest familySearchRequest);
+    Page<FamilySearchResult> searchFamilies(FamilySearchRequest familySearchRequest);
 
     FamilyDetail getFamilyDetail(Long familyId);
 

--- a/src/main/java/com/project/domain/family/service/FamilyService.java
+++ b/src/main/java/com/project/domain/family/service/FamilyService.java
@@ -3,14 +3,14 @@ package com.project.domain.family.service;
 import org.springframework.data.domain.Page;
 
 import com.project.domain.family.dto.request.FamilySearchRequest;
-import com.project.domain.family.dto.response.FamilyDetailResponse;
 import com.project.domain.family.dto.response.FamilySearchResponse;
+import com.project.domain.family.model.FamilyDetail;
 import com.project.domain.family.model.FamilyUsageReport;
 
 public interface FamilyService {
     Page<FamilySearchResponse> searchFamilies(FamilySearchRequest familySearchRequest);
 
-    FamilyDetailResponse getFamilyDetail(Long familyId);
+    FamilyDetail getFamilyDetail(Long familyId);
 
     FamilyUsageReport getFamilyUsageReport(Long customerId, int year, int month);
 

--- a/src/main/java/com/project/domain/family/service/FamilyServiceImpl.java
+++ b/src/main/java/com/project/domain/family/service/FamilyServiceImpl.java
@@ -41,28 +41,20 @@ public class FamilyServiceImpl implements FamilyService {
 
     @Override
     public FamilyDetailResponse getFamilyDetail(Long familyId) {
-        Family cachedFamily = familyCacheRepository.findById(familyId).orElse(null);
-
+        // 가족 상세 데이터는 DB에서 조회
         FamilyDetailResponse dbResponse =
                 familyQueryRepository
                         .findDetailById(familyId)
                         .orElseThrow(
                                 () -> new ApplicationException(FamilyErrorCode.FAMILY_NOT_FOUND));
 
-        if (cachedFamily == null) {
-            familyCacheRepository.save(dbResponse);
-            cachedFamily = familyCacheRepository.findById(familyId).orElse(null);
-        }
-
-        Long totalQuotaBytes =
-                cachedFamily != null
-                        ? cachedFamily.getTotalQuotaBytes()
-                        : dbResponse.totalQuotaBytes();
+        Long totalQuotaBytes = dbResponse.totalQuotaBytes();
 
         List<FamilyMemberDetailResponse> customers =
                 dbResponse.customers().stream()
                         .map(
                                 c ->
+                                        // 구성원별 실시간 사용량은 Redis 값이 있으면 덮어씀
                                         familyCacheRepository
                                                 .findCustomerMonthlyUsageBytes(
                                                         familyId, c.customerId())
@@ -77,6 +69,7 @@ public class FamilyServiceImpl implements FamilyService {
                                                 .orElse(c))
                         .toList();
 
+        // 응답 usedBytes/usedPercent는 보정된 구성원 사용량 합계를 기준으로 계산
         long finalUsedBytes =
                 customers.stream()
                         .map(FamilyMemberDetailResponse::monthlyUsedBytes)
@@ -91,19 +84,16 @@ public class FamilyServiceImpl implements FamilyService {
                         ? (double) finalUsedBytes / totalQuotaBytes * 100.0
                         : 0.0;
 
-        String familyName = cachedFamily != null ? cachedFamily.getName() : dbResponse.familyName();
-        Long createdById =
-                cachedFamily != null ? cachedFamily.getCreatedById() : dbResponse.createdById();
-
+        // 가족 메타 정보(name, quota, currentMonth 등)는 DB 조회 결과를 그대로 사용
         return new FamilyDetailResponse(
                 dbResponse.familyId(),
-                familyName,
-                createdById,
+                dbResponse.familyName(),
+                dbResponse.createdById(),
                 customers,
                 totalQuotaBytes,
                 finalUsedBytes,
                 usedPercent,
-                cachedFamily != null ? cachedFamily.getCurrentMonth() : dbResponse.currentMonth(),
+                dbResponse.currentMonth(),
                 dbResponse.createdAt(),
                 dbResponse.updatedAt());
     }

--- a/src/main/java/com/project/domain/family/service/FamilyServiceImpl.java
+++ b/src/main/java/com/project/domain/family/service/FamilyServiceImpl.java
@@ -17,6 +17,7 @@ import com.project.domain.family.model.FamilyUsageReport;
 import com.project.domain.family.repository.FamilyMemberRepository;
 import com.project.domain.family.repository.FamilyQueryRepository;
 import com.project.domain.family.repository.FamilyRepository;
+import com.project.domain.family.util.FamilyUsageCalculator;
 import com.project.global.exception.ApplicationException;
 import com.project.global.exception.code.FamilyErrorCode;
 
@@ -86,9 +87,7 @@ public class FamilyServiceImpl implements FamilyService {
                         .sum();
 
         double usedPercent =
-                (totalQuotaBytes != null && totalQuotaBytes > 0)
-                        ? (double) finalUsedBytes / totalQuotaBytes * 100.0
-                        : 0.0;
+                FamilyUsageCalculator.calculateUsedPercent(finalUsedBytes, totalQuotaBytes);
 
         // 가족 메타 정보(name, quota, currentMonth 등)는 DB 조회 결과를 그대로 사용
         return new FamilyDetail(

--- a/src/main/java/com/project/domain/family/service/FamilyServiceImpl.java
+++ b/src/main/java/com/project/domain/family/service/FamilyServiceImpl.java
@@ -8,11 +8,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.project.domain.family.dto.request.FamilySearchRequest;
-import com.project.domain.family.dto.response.FamilySearchResponse;
 import com.project.domain.family.entity.Family;
 import com.project.domain.family.infra.cache.FamilyCacheRepository;
 import com.project.domain.family.model.FamilyDetail;
 import com.project.domain.family.model.FamilyMemberDetail;
+import com.project.domain.family.model.FamilySearchResult;
 import com.project.domain.family.model.FamilyUsageReport;
 import com.project.domain.family.repository.FamilyMemberRepository;
 import com.project.domain.family.repository.FamilyQueryRepository;
@@ -35,7 +35,7 @@ public class FamilyServiceImpl implements FamilyService {
     private final FamilyRepository familyRepository;
 
     @Override
-    public Page<FamilySearchResponse> searchFamilies(FamilySearchRequest familySearchRequest) {
+    public Page<FamilySearchResult> searchFamilies(FamilySearchRequest familySearchRequest) {
         return familyQueryRepository.search(familySearchRequest);
     }
 

--- a/src/main/java/com/project/domain/family/service/FamilyServiceImpl.java
+++ b/src/main/java/com/project/domain/family/service/FamilyServiceImpl.java
@@ -8,11 +8,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.project.domain.family.dto.request.FamilySearchRequest;
-import com.project.domain.family.dto.response.FamilyDetailResponse;
-import com.project.domain.family.dto.response.FamilyMemberDetailResponse;
 import com.project.domain.family.dto.response.FamilySearchResponse;
 import com.project.domain.family.entity.Family;
 import com.project.domain.family.infra.cache.FamilyCacheRepository;
+import com.project.domain.family.model.FamilyDetail;
+import com.project.domain.family.model.FamilyMemberDetail;
 import com.project.domain.family.model.FamilyUsageReport;
 import com.project.domain.family.repository.FamilyMemberRepository;
 import com.project.domain.family.repository.FamilyQueryRepository;
@@ -40,18 +40,18 @@ public class FamilyServiceImpl implements FamilyService {
     }
 
     @Override
-    public FamilyDetailResponse getFamilyDetail(Long familyId) {
+    public FamilyDetail getFamilyDetail(Long familyId) {
         // 가족 상세 데이터는 DB에서 조회
-        FamilyDetailResponse dbResponse =
+        FamilyDetail familyDetail =
                 familyQueryRepository
                         .findDetailById(familyId)
                         .orElseThrow(
                                 () -> new ApplicationException(FamilyErrorCode.FAMILY_NOT_FOUND));
 
-        Long totalQuotaBytes = dbResponse.totalQuotaBytes();
+        Long totalQuotaBytes = familyDetail.totalQuotaBytes();
 
-        List<FamilyMemberDetailResponse> customers =
-                dbResponse.customers().stream()
+        List<FamilyMemberDetail> customers =
+                familyDetail.customers().stream()
                         .map(
                                 c ->
                                         // 구성원별 실시간 사용량은 Redis 값이 있으면 덮어씀
@@ -60,19 +60,25 @@ public class FamilyServiceImpl implements FamilyService {
                                                         familyId, c.customerId())
                                                 .map(
                                                         realtimeUsage ->
-                                                                new FamilyMemberDetailResponse(
+                                                                new FamilyMemberDetail(
                                                                         c.customerId(),
                                                                         c.name(),
                                                                         c.role(),
                                                                         c.monthlyLimitBytes(),
                                                                         realtimeUsage))
-                                                .orElse(c))
+                                                .orElse(
+                                                        new FamilyMemberDetail(
+                                                                c.customerId(),
+                                                                c.name(),
+                                                                c.role(),
+                                                                c.monthlyLimitBytes(),
+                                                                c.monthlyUsedBytes())))
                         .toList();
 
         // 응답 usedBytes/usedPercent는 보정된 구성원 사용량 합계를 기준으로 계산
         long finalUsedBytes =
                 customers.stream()
-                        .map(FamilyMemberDetailResponse::monthlyUsedBytes)
+                        .map(FamilyMemberDetail::monthlyUsedBytes)
                         .filter(
                                 monthlyUsedBytes ->
                                         monthlyUsedBytes != null && monthlyUsedBytes > 0)
@@ -85,17 +91,17 @@ public class FamilyServiceImpl implements FamilyService {
                         : 0.0;
 
         // 가족 메타 정보(name, quota, currentMonth 등)는 DB 조회 결과를 그대로 사용
-        return new FamilyDetailResponse(
-                dbResponse.familyId(),
-                dbResponse.familyName(),
-                dbResponse.createdById(),
+        return new FamilyDetail(
+                familyDetail.familyId(),
+                familyDetail.familyName(),
+                familyDetail.createdById(),
                 customers,
                 totalQuotaBytes,
                 finalUsedBytes,
                 usedPercent,
-                dbResponse.currentMonth(),
-                dbResponse.createdAt(),
-                dbResponse.updatedAt());
+                familyDetail.currentMonth(),
+                familyDetail.createdAt(),
+                familyDetail.updatedAt());
     }
 
     @Override

--- a/src/main/java/com/project/domain/family/util/FamilyUsageCalculator.java
+++ b/src/main/java/com/project/domain/family/util/FamilyUsageCalculator.java
@@ -1,0 +1,13 @@
+package com.project.domain.family.util;
+
+public final class FamilyUsageCalculator {
+
+    private FamilyUsageCalculator() {}
+
+    public static double calculateUsedPercent(Long usedBytes, Long totalQuotaBytes) {
+        if (usedBytes == null || totalQuotaBytes == null || totalQuotaBytes == 0L) {
+            return 0.0;
+        }
+        return (double) usedBytes / totalQuotaBytes * 100.0;
+    }
+}


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

<!-- 이슈 넘버와 티켓 넘버를 작성해주세요. 이슈가 닫히는 것을 원치 않으면 closed:를 지워주세요 -->

- closed: #35 
- jira: DABOM-201

---

## 🎯 목적

<!-- 왜 이 변경이 필요한지 배경과 목적을 작성해주세요. -->
현재 가족 상세 조회를 family:{fid}:info 를 타게 잘못 설계 되어있어서 DB만 타도록 변경

## 📝 변경 사항

<!-- 무엇을 변경했는지 리스트로 작성해주세요. -->

- `FamilyServiceImpl#getFamilyDetail`에서 `family:{fid}:info` 조회/저장 로직 제거
- 구성원 `monthlyUsedBytes`는 기존처럼 Redis 값 존재 시 덮어쓰기 유지

## 📂 변경 범위

<!-- 변경된 도메인/레이어를 표시해주세요. 해당 항목에 [x]로 체크해주세요. -->

| 도메인 | controller | service | repository | entity | infra | global |
| :----: | :--------: | :-----: | :--------: | :----: | :---: | :----: |
| family |            |    [x]  |            |        |       |        |

---

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. 단순 변경이면 섹션을 지워도 됩니다. -->

```java
// 가족 상세의 기준 데이터는 항상 DB에서 조회한다.
FamilyDetailResponse dbResponse = familyQueryRepository.findDetailById(familyId)...;

// 구성원별 실시간 사용량은 Redis 값이 있으면 덮어쓴다.
familyCacheRepository.findCustomerMonthlyUsageBytes(familyId, c.customerId())

// 응답 usedBytes/usedPercent는 보정된 구성원 사용량 합계를 기준으로 계산한다.
long finalUsedBytes = ...
double usedPercent = ...

// 가족 메타 정보(name, quota, currentMonth 등)는 DB 조회 결과를 그대로 사용한다.
return new FamilyDetailResponse(...);
```

## 💬 리뷰어에게

<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [x] 전체 변경사항이 500줄을 넘지 않는가?

**코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → Repository → Entity`)
- [x] Setter 없이 비즈니스 메서드로 상태를 변경하는가?
- [x] `@Transactional`은 Service에만 선언했는가?

**테스트**
- [ ] 신규 비즈니스 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

<!-- 추가로 공유할 내용이 있으면 작성해주세요. (관련 문서 링크, 후속 작업 등) -->
