### PR TITLE
[DABOM-369] 월 사용량 Redis 키를 usage:monthly:{yyyyMM}로 전환

### DIFF
--- a/src/main/java/com/project/domain/family/infra/cache/FamilyCacheRepository.java
+++ b/src/main/java/com/project/domain/family/infra/cache/FamilyCacheRepository.java
@@ -1,5 +1,7 @@
 package com.project.domain.family.infra.cache;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Optional;
 
 import org.springframework.data.redis.core.RedisTemplate;
@@ -15,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 @Repository
 @RequiredArgsConstructor
 public class FamilyCacheRepository {
+    private static final ZoneId ASIA_SEOUL = ZoneId.of("Asia/Seoul");
 
     private final RedisTemplate<String, String> familyStringRedisTemplate;
     private final RedisTemplate<String, FamilyCacheDto> familyCacheRedisTemplate;
@@ -60,7 +63,10 @@ public class FamilyCacheRepository {
     }
 
     public Optional<Long> findCustomerMonthlyUsageBytes(Long familyId, Long customerId) {
-        String key = redisKeyGenerator.generateFamilyCustomerMonthlyUsageKey(familyId, customerId);
+        LocalDate currentMonth = LocalDate.now(ASIA_SEOUL).withDayOfMonth(1);
+        String key =
+                redisKeyGenerator.generateFamilyCustomerMonthlyUsageKey(
+                        familyId, customerId, currentMonth);
         return findLongValue(key);
     }
 

--- a/src/main/java/com/project/global/util/RedisKeyGenerator.java
+++ b/src/main/java/com/project/global/util/RedisKeyGenerator.java
@@ -1,5 +1,8 @@
 package com.project.global.util;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
 import org.springframework.stereotype.Component;
 
 @Component
@@ -8,6 +11,8 @@ public class RedisKeyGenerator {
     private static final String KEY_SEPARATOR = ":";
     private static final String EXAMPLE_KEY_PREFIX = "example";
     private static final String FAMILY_KEY_PREFIX = "family";
+    private static final DateTimeFormatter MONTH_SUFFIX_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyyMM");
 
     public String generateExampleKey(Long exampleId) {
         return EXAMPLE_KEY_PREFIX + KEY_SEPARATOR + exampleId;
@@ -21,7 +26,8 @@ public class RedisKeyGenerator {
         return FAMILY_KEY_PREFIX + KEY_SEPARATOR + familyId + KEY_SEPARATOR + "remaining";
     }
 
-    public String generateFamilyCustomerMonthlyUsageKey(Long familyId, Long customerId) {
+    public String generateFamilyCustomerMonthlyUsageKey(
+            Long familyId, Long customerId, LocalDate targetMonth) {
         return FAMILY_KEY_PREFIX
                 + KEY_SEPARATOR
                 + familyId
@@ -32,7 +38,9 @@ public class RedisKeyGenerator {
                 + KEY_SEPARATOR
                 + "usage"
                 + KEY_SEPARATOR
-                + "monthly";
+                + "monthly"
+                + KEY_SEPARATOR
+                + targetMonth.format(MONTH_SUFFIX_FORMATTER);
     }
 
     public String generateFamilyKey(Long familyId) {


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

<!-- 이슈 넘버와 티켓 넘버를 작성해주세요. 이슈가 닫히는 것을 원치 않으면 closed:를 지워주세요 -->

- closed: #66 
- jira: DABOM-369

---

## 🎯 목적

<!-- 왜 이 변경이 필요한지 배경과 목적을 작성해주세요. -->
processor-usage에서 개인 월사용량 Redis 키가 `usage:monthly:{yyyyMM}`로 변경됨에 따라 api-core도 변경

## 📝 변경 사항

<!-- 무엇을 변경했는지 리스트로 작성해주세요. -->

- `RedisKeyGenerator` 월사용량 키 생성 시 `LocalDate targetMonth`를 받아 `yyyyMM` suffix를 붙이도록 변경
- `FamilyCacheRepository.findCustomerMonthlyUsageBytes`에서 `Asia/Seoul` 현재월 기준 키를 조회하도록 변경

## 📂 변경 범위

<!-- 변경된 도메인/레이어를 표시해주세요. 해당 항목에 [x]로 체크해주세요. -->

| 도메인 | controller | service | repository | entity | infra | global |
| :----: | :--------: | :-----: | :--------: | :----: | :---: | :----: |
| family |            |         |            |        |  [x]  |        |
| common |            |         |            |        |       |   [x]  |

---

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. 단순 변경이면 섹션을 지워도 됩니다. -->

```java
// RedisKeyGenerator
public String generateFamilyCustomerMonthlyUsageKey(
        Long familyId, Long customerId, LocalDate targetMonth) {
    return "family:" + familyId + ":customer:" + customerId + ":usage:monthly:"
            + targetMonth.format(DateTimeFormatter.ofPattern("yyyyMM"));
}

// FamilyCacheRepository
LocalDate currentMonth = LocalDate.now(ZoneId.of("Asia/Seoul")).withDayOfMonth(1);
String key =
        redisKeyGenerator.generateFamilyCustomerMonthlyUsageKey(
                familyId, customerId, currentMonth);
```

## 💬 리뷰어에게

<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
- 이번 PR은 api-core 조회 경로만 월 suffix 키로 정렬한 변경입니다
---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [x] 전체 변경사항이 500줄을 넘지 않는가?

**코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → Repository → Entity`)
- [x] Setter 없이 비즈니스 메서드로 상태를 변경하는가?
- [x] `@Transactional`은 Service에만 선언했는가?

**테스트**
- [ ] 신규 비즈니스 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

<!-- 추가로 공유할 내용이 있으면 작성해주세요. (관련 문서 링크, 후속 작업 등) -->
