### PR TITLE
[DABOM-286] 어필 상세조회, 생성, 긴급 요청 API 구현 

### DIFF
--- a/src/main/java/com/project/domain/appeal/controller/AppealController.java
+++ b/src/main/java/com/project/domain/appeal/controller/AppealController.java
@@ -1,17 +1,29 @@
 package com.project.domain.appeal.controller;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.project.domain.appeal.dto.request.AppealCreateRequest;
+import com.project.domain.appeal.dto.request.EmergencyQuotaRequest;
+import com.project.domain.appeal.dto.response.AppealCreateResponse;
+import com.project.domain.appeal.dto.response.AppealDetailResponse;
 import com.project.domain.appeal.dto.response.AppealListResponse;
+import com.project.domain.appeal.dto.response.EmergencyQuotaResponse;
 import com.project.domain.appeal.enums.AppealStatus;
+import com.project.domain.appeal.model.AppealCreateResult;
+import com.project.domain.appeal.model.AppealDetailResult;
 import com.project.domain.appeal.model.AppealListResult;
+import com.project.domain.appeal.model.EmergencyQuotaResult;
 import com.project.domain.appeal.service.AppealService;
 import com.project.global.api.response.ApiResponse;
 import com.project.global.auth.aop.CustomerId;
@@ -24,6 +36,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 import lombok.RequiredArgsConstructor;
 
+/** 이의제기 API 컨트롤러 */
 @RestController
 @Validated
 @RequiredArgsConstructor
@@ -45,5 +58,40 @@ public class AppealController {
         AuthContext auth = authContextService.resolve(customerId);
         AppealListResult result = appealService.getAppeals(auth, status, cursor, size);
         return ApiResponse.success(AppealListResponse.from(result));
+    }
+
+    /** 이의제기 상세 조회 처리 */
+    @GetMapping("/{appealId}")
+    @Operation(summary = "이의제기 상세 조회")
+    public ApiResponse<AppealDetailResponse> getAppealDetail(
+            @Parameter(hidden = true) @CustomerId Long customerId,
+            @PathVariable Long appealId,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size) {
+        AuthContext auth = authContextService.resolve(customerId);
+        AppealDetailResult result = appealService.getAppealDetail(auth, appealId, cursor, size);
+        return ApiResponse.success(AppealDetailResponse.from(result));
+    }
+
+    /** 이의제기 생성 처리 */
+    @PostMapping
+    @Operation(summary = "이의제기 생성")
+    public ApiResponse<AppealCreateResponse> createAppeal(
+            @Parameter(hidden = true) @CustomerId Long customerId,
+            @RequestBody @Valid AppealCreateRequest request) {
+        AuthContext auth = authContextService.resolve(customerId);
+        AppealCreateResult result = appealService.createAppeal(auth, request);
+        return ApiResponse.created(AppealCreateResponse.from(result));
+    }
+
+    /** 긴급 쿼터 요청 처리 */
+    @PostMapping("/emergency")
+    @Operation(summary = "긴급 쿼터 요청")
+    public ApiResponse<EmergencyQuotaResponse> requestEmergencyQuota(
+            @Parameter(hidden = true) @CustomerId Long customerId,
+            @RequestBody @Valid EmergencyQuotaRequest request) {
+        AuthContext auth = authContextService.resolve(customerId);
+        EmergencyQuotaResult result = appealService.requestEmergencyQuota(auth, request);
+        return ApiResponse.created(EmergencyQuotaResponse.from(result));
     }
 }

--- a/src/main/java/com/project/domain/appeal/dto/request/AppealCreateRequest.java
+++ b/src/main/java/com/project/domain/appeal/dto/request/AppealCreateRequest.java
@@ -1,0 +1,13 @@
+package com.project.domain.appeal.dto.request;
+
+import java.util.Map;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+/** 이의제기 생성 요청 DTO */
+public record AppealCreateRequest(
+        @NotNull @Positive Long policyAssignmentId,
+        @NotBlank String requestReason,
+        Map<String, Object> desiredRules) {}

--- a/src/main/java/com/project/domain/appeal/dto/request/EmergencyQuotaRequest.java
+++ b/src/main/java/com/project/domain/appeal/dto/request/EmergencyQuotaRequest.java
@@ -1,0 +1,9 @@
+package com.project.domain.appeal.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+/** 긴급 쿼터 요청 DTO */
+public record EmergencyQuotaRequest(
+        @NotBlank String requestReason, @NotNull @Positive Long additionalBytes) {}

--- a/src/main/java/com/project/domain/appeal/dto/response/AppealCreateResponse.java
+++ b/src/main/java/com/project/domain/appeal/dto/response/AppealCreateResponse.java
@@ -1,0 +1,26 @@
+package com.project.domain.appeal.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import com.project.domain.appeal.enums.AppealStatus;
+import com.project.domain.appeal.model.AppealCreateResult;
+
+/** 이의제기 생성 응답 */
+public record AppealCreateResponse(
+        Long appealId,
+        Long policyAssignmentId,
+        AppealStatus status,
+        Map<String, Object> desiredRules,
+        LocalDateTime createdAt) {
+
+    /** 생성 결과 응답 변환 */
+    public static AppealCreateResponse from(AppealCreateResult result) {
+        return new AppealCreateResponse(
+                result.appealId(),
+                result.policyAssignmentId(),
+                result.status(),
+                result.desiredRules(),
+                result.createdAt());
+    }
+}

--- a/src/main/java/com/project/domain/appeal/dto/response/AppealDetailResponse.java
+++ b/src/main/java/com/project/domain/appeal/dto/response/AppealDetailResponse.java
@@ -1,0 +1,76 @@
+package com.project.domain.appeal.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import com.project.domain.appeal.enums.AppealStatus;
+import com.project.domain.appeal.model.AppealDetailResult;
+import com.project.domain.policy.enums.PolicyType;
+
+/** 이의제기 상세 조회 응답 */
+public record AppealDetailResponse(
+        Long appealId,
+        Long policyAssignmentId,
+        PolicyType policyType,
+        Long requesterId,
+        String requesterName,
+        String requestReason,
+        String rejectReason,
+        Map<String, Object> desiredRules,
+        AppealStatus status,
+        Long resolvedById,
+        LocalDateTime resolvedAt,
+        LocalDateTime createdAt,
+        CommentPageResponse comments) {
+
+    /** 상세 조회 결과 응답 변환 */
+    public static AppealDetailResponse from(AppealDetailResult result) {
+        return new AppealDetailResponse(
+                result.appealId(),
+                result.policyAssignmentId(),
+                result.policyType(),
+                result.requesterId(),
+                result.requesterName(),
+                result.requestReason(),
+                result.rejectReason(),
+                result.desiredRules(),
+                result.status(),
+                result.resolvedById(),
+                result.resolvedAt(),
+                result.createdAt(),
+                CommentPageResponse.from(result.comments()));
+    }
+
+    /** 댓글 페이지 응답 */
+    public record CommentPageResponse(
+            List<CommentItemResponse> content, String nextCursor, boolean hasNext) {
+
+        /** 댓글 페이지 응답 변환 */
+        public static CommentPageResponse from(AppealDetailResult.CommentPage comments) {
+            return new CommentPageResponse(
+                    comments.content().stream().map(CommentItemResponse::from).toList(),
+                    comments.nextCursor(),
+                    comments.hasNext());
+        }
+    }
+
+    /** 댓글 항목 응답 */
+    public record CommentItemResponse(
+            Long commentId,
+            Long authorId,
+            String authorName,
+            String comment,
+            LocalDateTime createdAt) {
+
+        /** 댓글 항목 응답 변환 */
+        public static CommentItemResponse from(AppealDetailResult.CommentItem comment) {
+            return new CommentItemResponse(
+                    comment.commentId(),
+                    comment.authorId(),
+                    comment.authorName(),
+                    comment.comment(),
+                    comment.createdAt());
+        }
+    }
+}

--- a/src/main/java/com/project/domain/appeal/dto/response/EmergencyQuotaResponse.java
+++ b/src/main/java/com/project/domain/appeal/dto/response/EmergencyQuotaResponse.java
@@ -1,0 +1,30 @@
+package com.project.domain.appeal.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.project.domain.appeal.enums.AppealStatus;
+import com.project.domain.appeal.enums.AppealType;
+import com.project.domain.appeal.model.EmergencyQuotaResult;
+
+/** 긴급 쿼터 요청 응답 */
+public record EmergencyQuotaResponse(
+        Long appealId,
+        AppealType type,
+        AppealStatus status,
+        Long additionalBytes,
+        Long newMonthlyLimitBytes,
+        String requestReason,
+        LocalDateTime createdAt) {
+
+    /** 긴급 쿼터 결과 응답 변환 */
+    public static EmergencyQuotaResponse from(EmergencyQuotaResult result) {
+        return new EmergencyQuotaResponse(
+                result.appealId(),
+                result.type(),
+                result.status(),
+                result.additionalBytes(),
+                result.newMonthlyLimitBytes(),
+                result.requestReason(),
+                result.createdAt());
+    }
+}

--- a/src/main/java/com/project/domain/appeal/entity/PolicyAppeal.java
+++ b/src/main/java/com/project/domain/appeal/entity/PolicyAppeal.java
@@ -1,5 +1,6 @@
 package com.project.domain.appeal.entity;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Map;
 
@@ -12,6 +13,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 
 import com.project.domain.appeal.enums.AppealStatus;
 import com.project.domain.appeal.enums.AppealType;
@@ -26,7 +28,13 @@ import lombok.NoArgsConstructor;
 
 /** 이의제기 엔티티 */
 @Entity
-@Table(name = "policy_appeal")
+@Table(
+        name = "policy_appeal",
+        uniqueConstraints = {
+            @UniqueConstraint(
+                    name = "uk_policy_appeal_emergency_month",
+                    columnNames = {"requester_id", "emergency_grant_month"})
+        })
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -71,4 +79,7 @@ public class PolicyAppeal extends BaseEntity {
 
     @Column(name = "cancelled_at")
     private LocalDateTime cancelledAt;
+
+    @Column(name = "emergency_grant_month")
+    private LocalDate emergencyGrantMonth;
 }

--- a/src/main/java/com/project/domain/appeal/entity/PolicyAppealComment.java
+++ b/src/main/java/com/project/domain/appeal/entity/PolicyAppealComment.java
@@ -1,0 +1,49 @@
+package com.project.domain.appeal.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import com.project.global.util.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 이의제기 댓글 엔티티 */
+@Entity
+@Table(name = "policy_appeal_comment")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PolicyAppealComment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "appeal_id", nullable = false)
+    private Long appealId;
+
+    @Column(name = "author_id", nullable = false)
+    private Long authorId;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String comment;
+
+    public void delete() {
+        softDelete();
+    }
+
+    public LocalDateTime getDeletedAtValue() {
+        return getDeletedAt();
+    }
+}

--- a/src/main/java/com/project/domain/appeal/entity/PolicyAppealComment.java
+++ b/src/main/java/com/project/domain/appeal/entity/PolicyAppealComment.java
@@ -1,7 +1,5 @@
 package com.project.domain.appeal.entity;
 
-import java.time.LocalDateTime;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -41,9 +39,5 @@ public class PolicyAppealComment extends BaseEntity {
 
     public void delete() {
         softDelete();
-    }
-
-    public LocalDateTime getDeletedAtValue() {
-        return getDeletedAt();
     }
 }

--- a/src/main/java/com/project/domain/appeal/model/AppealCreateResult.java
+++ b/src/main/java/com/project/domain/appeal/model/AppealCreateResult.java
@@ -1,0 +1,14 @@
+package com.project.domain.appeal.model;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import com.project.domain.appeal.enums.AppealStatus;
+
+/** 이의제기 생성 결과 모델 */
+public record AppealCreateResult(
+        Long appealId,
+        Long policyAssignmentId,
+        AppealStatus status,
+        Map<String, Object> desiredRules,
+        LocalDateTime createdAt) {}

--- a/src/main/java/com/project/domain/appeal/model/AppealDetailResult.java
+++ b/src/main/java/com/project/domain/appeal/model/AppealDetailResult.java
@@ -1,0 +1,36 @@
+package com.project.domain.appeal.model;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import com.project.domain.appeal.enums.AppealStatus;
+import com.project.domain.policy.enums.PolicyType;
+
+/** 이의제기 상세 조회 결과 모델 */
+public record AppealDetailResult(
+        Long appealId,
+        Long policyAssignmentId,
+        PolicyType policyType,
+        Long requesterId,
+        String requesterName,
+        String requestReason,
+        String rejectReason,
+        Map<String, Object> desiredRules,
+        AppealStatus status,
+        Long resolvedById,
+        LocalDateTime resolvedAt,
+        LocalDateTime createdAt,
+        CommentPage comments) {
+
+    /** 댓글 커서 페이지 결과 모델 */
+    public record CommentPage(List<CommentItem> content, String nextCursor, boolean hasNext) {}
+
+    /** 댓글 항목 모델 */
+    public record CommentItem(
+            Long commentId,
+            Long authorId,
+            String authorName,
+            String comment,
+            LocalDateTime createdAt) {}
+}

--- a/src/main/java/com/project/domain/appeal/model/EmergencyQuotaResult.java
+++ b/src/main/java/com/project/domain/appeal/model/EmergencyQuotaResult.java
@@ -1,0 +1,16 @@
+package com.project.domain.appeal.model;
+
+import java.time.LocalDateTime;
+
+import com.project.domain.appeal.enums.AppealStatus;
+import com.project.domain.appeal.enums.AppealType;
+
+/** 긴급 쿼터 요청 결과 모델 */
+public record EmergencyQuotaResult(
+        Long appealId,
+        AppealType type,
+        AppealStatus status,
+        Long additionalBytes,
+        Long newMonthlyLimitBytes,
+        String requestReason,
+        LocalDateTime createdAt) {}

--- a/src/main/java/com/project/domain/appeal/repository/PolicyAppealCommentRepository.java
+++ b/src/main/java/com/project/domain/appeal/repository/PolicyAppealCommentRepository.java
@@ -1,0 +1,27 @@
+package com.project.domain.appeal.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.project.domain.appeal.entity.PolicyAppealComment;
+
+/** 이의제기 상세 조회(댓글 조회) 저장소 */
+public interface PolicyAppealCommentRepository extends JpaRepository<PolicyAppealComment, Long> {
+
+    /** 이의제기 상세 조회(댓글 커서) 조회 */
+    @Query(
+            """
+            select pac
+            from PolicyAppealComment pac
+            where pac.appealId = :appealId
+              and (:cursorId is null or pac.id < :cursorId)
+              and pac.deletedAt is null
+            order by pac.id desc
+            """)
+    List<PolicyAppealComment> findByAppealIdAndIdLessThanOrderByIdDesc(
+            @Param("appealId") Long appealId, @Param("cursorId") Long cursorId, Pageable pageable);
+}

--- a/src/main/java/com/project/domain/appeal/repository/PolicyAppealRepository.java
+++ b/src/main/java/com/project/domain/appeal/repository/PolicyAppealRepository.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import com.project.domain.appeal.enums.AppealType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -12,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 
 import com.project.domain.appeal.entity.PolicyAppeal;
 import com.project.domain.appeal.enums.AppealStatus;
+import com.project.domain.appeal.enums.AppealType;
 
 /** 이의제기 목록 조회 저장소 */
 public interface PolicyAppealRepository extends JpaRepository<PolicyAppeal, Long> {

--- a/src/main/java/com/project/domain/appeal/repository/PolicyAppealRepository.java
+++ b/src/main/java/com/project/domain/appeal/repository/PolicyAppealRepository.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import com.project.domain.appeal.enums.AppealType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -16,6 +17,10 @@ import com.project.domain.appeal.enums.AppealStatus;
 public interface PolicyAppealRepository extends JpaRepository<PolicyAppeal, Long> {
 
     Optional<PolicyAppeal> findByIdAndDeletedAtIsNull(Long id);
+
+    /** 동일 정책 진행 중 이의제기 존재 여부 확인 */
+    boolean existsByPolicyAssignmentIdAndRequesterIdAndTypeAndStatusAndDeletedAtIsNull(
+            Long policyAssignmentId, Long requesterId, AppealType type, AppealStatus status);
 
     /** 가족 기준 이의제기 목록 조회 */
     @Query(
@@ -76,7 +81,7 @@ public interface PolicyAppealRepository extends JpaRepository<PolicyAppeal, Long
             """)
     List<PolicyAppeal> findByRequesterIdAndTypeAndStatusAndCreatedAtBetween(
             @Param("requesterId") Long requesterId,
-            @Param("type") com.project.domain.appeal.enums.AppealType type,
+            @Param("type") AppealType type,
             @Param("status") AppealStatus status,
             @Param("from") LocalDateTime from,
             @Param("to") LocalDateTime to);

--- a/src/main/java/com/project/domain/appeal/repository/PolicyAppealRepository.java
+++ b/src/main/java/com/project/domain/appeal/repository/PolicyAppealRepository.java
@@ -1,6 +1,8 @@
 package com.project.domain.appeal.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,6 +14,8 @@ import com.project.domain.appeal.enums.AppealStatus;
 
 /** 이의제기 목록 조회 저장소 */
 public interface PolicyAppealRepository extends JpaRepository<PolicyAppeal, Long> {
+
+    Optional<PolicyAppeal> findByIdAndDeletedAtIsNull(Long id);
 
     /** 가족 기준 이의제기 목록 조회 */
     @Query(
@@ -58,4 +62,22 @@ public interface PolicyAppealRepository extends JpaRepository<PolicyAppeal, Long
             @Param("status") AppealStatus status,
             @Param("cursorId") Long cursorId,
             Pageable pageable);
+
+    /** 긴급 요청 월별 승인 이력 조회 */
+    @Query(
+            """
+            select pa
+            from PolicyAppeal pa
+            where pa.requesterId = :requesterId
+              and pa.type = :type
+              and pa.status = :status
+              and pa.createdAt between :from and :to
+              and pa.deletedAt is null
+            """)
+    List<PolicyAppeal> findByRequesterIdAndTypeAndStatusAndCreatedAtBetween(
+            @Param("requesterId") Long requesterId,
+            @Param("type") com.project.domain.appeal.enums.AppealType type,
+            @Param("status") AppealStatus status,
+            @Param("from") LocalDateTime from,
+            @Param("to") LocalDateTime to);
 }

--- a/src/main/java/com/project/domain/appeal/service/AppealService.java
+++ b/src/main/java/com/project/domain/appeal/service/AppealService.java
@@ -1,11 +1,25 @@
 package com.project.domain.appeal.service;
 
+import com.project.domain.appeal.dto.request.AppealCreateRequest;
+import com.project.domain.appeal.dto.request.EmergencyQuotaRequest;
 import com.project.domain.appeal.enums.AppealStatus;
+import com.project.domain.appeal.model.AppealCreateResult;
+import com.project.domain.appeal.model.AppealDetailResult;
 import com.project.domain.appeal.model.AppealListResult;
+import com.project.domain.appeal.model.EmergencyQuotaResult;
 import com.project.global.auth.model.AuthContext;
 
-/** 이의제기 목록 조회 서비스 명세 */
+/** 이의제기 서비스 명세 */
 public interface AppealService {
     /** 이의제기 목록 조회 */
     AppealListResult getAppeals(AuthContext auth, AppealStatus status, Long cursor, int size);
+
+    /** 이의제기 상세 조회 */
+    AppealDetailResult getAppealDetail(AuthContext auth, Long appealId, Long cursor, int size);
+
+    /** 이의제기 생성 */
+    AppealCreateResult createAppeal(AuthContext auth, AppealCreateRequest request);
+
+    /** 긴급 쿼터 요청 */
+    EmergencyQuotaResult requestEmergencyQuota(AuthContext auth, EmergencyQuotaRequest request);
 }

--- a/src/main/java/com/project/domain/appeal/service/AppealServiceImpl.java
+++ b/src/main/java/com/project/domain/appeal/service/AppealServiceImpl.java
@@ -1,5 +1,9 @@
 package com.project.domain.appeal.service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -9,17 +13,39 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.project.domain.appeal.dto.request.AppealCreateRequest;
+import com.project.domain.appeal.dto.request.EmergencyQuotaRequest;
 import com.project.domain.appeal.entity.PolicyAppeal;
+import com.project.domain.appeal.entity.PolicyAppealComment;
 import com.project.domain.appeal.enums.AppealStatus;
+import com.project.domain.appeal.enums.AppealType;
+import com.project.domain.appeal.model.AppealCreateResult;
+import com.project.domain.appeal.model.AppealDetailResult;
 import com.project.domain.appeal.model.AppealListResult;
+import com.project.domain.appeal.model.EmergencyQuotaResult;
+import com.project.domain.appeal.repository.PolicyAppealCommentRepository;
 import com.project.domain.appeal.repository.PolicyAppealRepository;
 import com.project.domain.customer.entity.Customer;
+import com.project.domain.customer.entity.CustomerQuota;
+import com.project.domain.customer.enums.RoleType;
+import com.project.domain.customer.repository.CustomerQuotaRepository;
 import com.project.domain.customer.repository.CustomerRepository;
+import com.project.domain.family.entity.FamilyMember;
+import com.project.domain.family.repository.FamilyMemberRepository;
+import com.project.domain.policy.entity.Policy;
+import com.project.domain.policy.entity.PolicyAssignment;
+import com.project.domain.policy.enums.PolicyType;
+import com.project.domain.policy.repository.PolicyAssignmentRepository;
+import com.project.domain.policy.repository.PolicyRepository;
 import com.project.global.auth.model.AuthContext;
+import com.project.global.exception.ApplicationException;
+import com.project.global.exception.code.AppealErrorCode;
+import com.project.global.exception.code.CustomerErrorCode;
+import com.project.global.exception.code.PolicyErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
-/** 이의제기 목록 조회 서비스 구현 */
+/** 이의제기 서비스 구현 */
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -28,9 +54,16 @@ public class AppealServiceImpl implements AppealService {
     private static final int DEFAULT_CURSOR_SIZE = 20;
     private static final int MAX_CURSOR_SIZE = 100;
     private static final String UNKNOWN_NAME = "unknown";
+    private static final long MIN_EMERGENCY_BYTES = 104_857_600L;
+    private static final long MAX_EMERGENCY_BYTES = 314_572_800L;
 
     private final PolicyAppealRepository policyAppealRepository;
+    private final PolicyAppealCommentRepository policyAppealCommentRepository;
     private final CustomerRepository customerRepository;
+    private final FamilyMemberRepository familyMemberRepository;
+    private final PolicyAssignmentRepository policyAssignmentRepository;
+    private final PolicyRepository policyRepository;
+    private final CustomerQuotaRepository customerQuotaRepository;
 
     /** 이의제기 목록 조회 */
     @Override
@@ -38,6 +71,7 @@ public class AppealServiceImpl implements AppealService {
             AuthContext auth, AppealStatus status, Long cursor, int size) {
         // 1. 요청 size를 기본값과 최대값 범위 안으로 보정한다.
         int pageSize = normalizeSize(size);
+
         // 2. 역할에 따라 OWNER는 가족 전체, MEMBER는 본인 이의제기만 조회한다.
         List<PolicyAppeal> appeals =
                 auth.isOwner()
@@ -54,13 +88,167 @@ public class AppealServiceImpl implements AppealService {
         boolean hasNext = appeals.size() > pageSize;
         List<PolicyAppeal> page = hasNext ? appeals.subList(0, pageSize) : appeals;
         String nextCursor = hasNext ? String.valueOf(page.getLast().getId()) : null;
-        Map<Long, String> customerNameMap = loadCustomerNameMap(page);
+        Map<Long, String> customerNameMap = loadCustomerNameMap(extractRequesterIds(page));
 
         // 4. 현재 페이지 엔티티를 응답 모델로 변환해 목록 결과를 반환한다.
         return new AppealListResult(
                 page.stream().map(appeal -> toAppealSummary(appeal, customerNameMap)).toList(),
                 nextCursor,
                 hasNext);
+    }
+
+    /** 이의제기 상세 조회 */
+    @Override
+    public AppealDetailResult getAppealDetail(
+            AuthContext auth, Long appealId, Long cursor, int size) {
+        // 1. 이의제기 존재 여부와 가족 접근 가능 여부를 확인한다.
+        PolicyAppeal appeal = findAppealOrThrow(appealId);
+        validateFamilyAccess(auth.familyId(), appeal);
+
+        // 2. 댓글 size를 보정하고 커서 기반으로 댓글을 조회한다.
+        int pageSize = normalizeSize(size);
+        List<PolicyAppealComment> comments =
+                policyAppealCommentRepository.findByAppealIdAndIdLessThanOrderByIdDesc(
+                        appealId, cursor, PageRequest.of(0, pageSize + 1));
+
+        // 3. pageSize + 1 조회 결과로 댓글 nextCursor와 hasNext를 계산한다.
+        boolean hasNext = comments.size() > pageSize;
+        List<PolicyAppealComment> page = hasNext ? comments.subList(0, pageSize) : comments;
+        String nextCursor = hasNext ? String.valueOf(page.getLast().getId()) : null;
+
+        // 4. 요청자, 처리자, 댓글 작성자 이름과 정책 타입을 조회해 상세 응답으로 변환한다.
+        Set<Long> customerIds = new HashSet<>();
+        customerIds.add(appeal.getRequesterId());
+        if (appeal.getResolvedById() != null) {
+            customerIds.add(appeal.getResolvedById());
+        }
+        page.stream().map(PolicyAppealComment::getAuthorId).forEach(customerIds::add);
+
+        Map<Long, String> customerNameMap = loadCustomerNameMap(customerIds);
+        PolicyType policyType = resolvePolicyType(appeal);
+
+        return new AppealDetailResult(
+                appeal.getId(),
+                appeal.getPolicyAssignmentId(),
+                policyType,
+                appeal.getRequesterId(),
+                customerNameMap.getOrDefault(appeal.getRequesterId(), UNKNOWN_NAME),
+                appeal.getRequestReason(),
+                appeal.getRejectReason(),
+                appeal.getDesiredRules(),
+                appeal.getStatus(),
+                appeal.getResolvedById(),
+                appeal.getResolvedAt(),
+                appeal.getCreatedAt(),
+                new AppealDetailResult.CommentPage(
+                        page.stream()
+                                .map(comment -> toCommentItem(comment, customerNameMap))
+                                .toList(),
+                        nextCursor,
+                        hasNext));
+    }
+
+    /** 이의제기 생성 */
+    @Override
+    @Transactional
+    public AppealCreateResult createAppeal(AuthContext auth, AppealCreateRequest request) {
+        // 1. MEMBER 역할만 일반 이의제기를 생성할 수 있다.
+        validateMemberOnly(auth);
+
+        // 2. 정책 할당이 존재하고 같은 가족 소속인지 확인한다.
+        PolicyAssignment policyAssignment =
+                policyAssignmentRepository
+                        .findByIdAndDeletedAtIsNull(request.policyAssignmentId())
+                        .orElseThrow(
+                                () ->
+                                        new ApplicationException(
+                                                PolicyErrorCode.POLICY_ASSIGNMENT_NOT_FOUND));
+        if (!policyAssignment.getFamilyId().equals(auth.familyId())) {
+            throw new ApplicationException(AppealErrorCode.APPEAL_FORBIDDEN);
+        }
+
+        // 3. NORMAL/PENDING 상태의 이의제기를 저장한다.
+        PolicyAppeal appeal =
+                policyAppealRepository.save(
+                        PolicyAppeal.builder()
+                                .type(AppealType.NORMAL)
+                                .policyAssignmentId(policyAssignment.getId())
+                                .requesterId(auth.customerId())
+                                .requestReason(request.requestReason())
+                                .desiredRules(request.desiredRules())
+                                .status(AppealStatus.PENDING)
+                                .build());
+
+        // 4. 생성 결과를 응답 모델로 반환한다.
+        return new AppealCreateResult(
+                appeal.getId(),
+                appeal.getPolicyAssignmentId(),
+                appeal.getStatus(),
+                appeal.getDesiredRules(),
+                appeal.getCreatedAt());
+    }
+
+    /** 긴급 쿼터 요청 */
+    @Override
+    @Transactional
+    public EmergencyQuotaResult requestEmergencyQuota(
+            AuthContext auth, EmergencyQuotaRequest request) {
+        // 1. MEMBER 역할과 요청 바이트 범위를 검증한다.
+        validateMemberOnly(auth);
+        validateEmergencyBytes(request.additionalBytes());
+
+        // 2. 현재 월에 승인된 긴급 요청이 이미 있는지 확인한다.
+        LocalDateTime monthStart = YearMonth.now().atDay(1).atStartOfDay();
+        LocalDateTime monthEnd = YearMonth.now().atEndOfMonth().atTime(23, 59, 59);
+        boolean alreadyApproved =
+                !policyAppealRepository
+                        .findByRequesterIdAndTypeAndStatusAndCreatedAtBetween(
+                                auth.customerId(),
+                                AppealType.EMERGENCY,
+                                AppealStatus.APPROVED,
+                                monthStart,
+                                monthEnd)
+                        .isEmpty();
+        if (alreadyApproved) {
+            throw new ApplicationException(AppealErrorCode.APPEAL_EMERGENCY_MONTHLY_LIMIT);
+        }
+
+        // 3. 당월 고객 쿼터를 조회하고 무제한 사용자 여부를 확인한다.
+        CustomerQuota customerQuota =
+                customerQuotaRepository
+                        .findByFamilyIdAndCustomerIdAndCurrentMonthAndDeletedAtIsNull(
+                                auth.familyId(),
+                                auth.customerId(),
+                                LocalDate.now().withDayOfMonth(1))
+                        .orElseThrow(
+                                () ->
+                                        new ApplicationException(
+                                                CustomerErrorCode.CUSTOMER_NOT_FOUND));
+        if (customerQuota.getMonthlyLimitBytes() == null) {
+            throw new ApplicationException(AppealErrorCode.APPEAL_EMERGENCY_UNLIMITED);
+        }
+
+        // 4. APPROVED 상태의 긴급 이의제기를 저장하고 월 한도를 즉시 증가시킨다.
+        PolicyAppeal appeal =
+                policyAppealRepository.save(
+                        PolicyAppeal.builder()
+                                .type(AppealType.EMERGENCY)
+                                .requesterId(auth.customerId())
+                                .requestReason(request.requestReason())
+                                .desiredRules(Map.of("additionalBytes", request.additionalBytes()))
+                                .status(AppealStatus.APPROVED)
+                                .build());
+        customerQuota.addMonthlyLimitBytes(request.additionalBytes());
+
+        // 5. 긴급 쿼터 결과를 응답 모델로 반환한다.
+        return new EmergencyQuotaResult(
+                appeal.getId(),
+                appeal.getType(),
+                appeal.getStatus(),
+                request.additionalBytes(),
+                customerQuota.getMonthlyLimitBytes(),
+                appeal.getRequestReason(),
+                appeal.getCreatedAt());
     }
 
     /** 이의제기 요약 모델 변환 */
@@ -78,10 +266,82 @@ public class AppealServiceImpl implements AppealService {
                 appeal.getCreatedAt());
     }
 
-    /** 요청자 이름 일괄 조회 */
-    private Map<Long, String> loadCustomerNameMap(List<PolicyAppeal> appeals) {
-        Set<Long> customerIds =
-                appeals.stream().map(PolicyAppeal::getRequesterId).collect(Collectors.toSet());
+    /** 댓글 항목 모델 변환 */
+    private AppealDetailResult.CommentItem toCommentItem(
+            PolicyAppealComment comment, Map<Long, String> customerNameMap) {
+        return new AppealDetailResult.CommentItem(
+                comment.getId(),
+                comment.getAuthorId(),
+                customerNameMap.getOrDefault(comment.getAuthorId(), UNKNOWN_NAME),
+                comment.getComment(),
+                comment.getCreatedAt());
+    }
+
+    /** 이의제기 존재 여부 확인 */
+    private PolicyAppeal findAppealOrThrow(Long appealId) {
+        return policyAppealRepository
+                .findByIdAndDeletedAtIsNull(appealId)
+                .orElseThrow(() -> new ApplicationException(AppealErrorCode.APPEAL_NOT_FOUND));
+    }
+
+    /** 같은 가족 접근 가능 여부 검증 */
+    private void validateFamilyAccess(Long familyId, PolicyAppeal appeal) {
+        FamilyMember requester =
+                familyMemberRepository
+                        .findByCustomerId(appeal.getRequesterId())
+                        .orElseThrow(
+                                () -> new ApplicationException(AppealErrorCode.APPEAL_FORBIDDEN));
+        if (!requester.getFamilyId().equals(familyId)) {
+            throw new ApplicationException(AppealErrorCode.APPEAL_FORBIDDEN);
+        }
+    }
+
+    /** MEMBER 전용 기능 여부 검증 */
+    private void validateMemberOnly(AuthContext auth) {
+        if (!RoleType.MEMBER.equals(auth.role())) {
+            throw new ApplicationException(AppealErrorCode.APPEAL_FORBIDDEN);
+        }
+    }
+
+    /** 긴급 요청 바이트 범위 검증 */
+    private void validateEmergencyBytes(Long additionalBytes) {
+        if (additionalBytes < MIN_EMERGENCY_BYTES || additionalBytes > MAX_EMERGENCY_BYTES) {
+            throw new ApplicationException(AppealErrorCode.APPEAL_EMERGENCY_INVALID_BYTES);
+        }
+    }
+
+    /** 정책 타입 조회 */
+    private PolicyType resolvePolicyType(PolicyAppeal appeal) {
+        if (AppealType.EMERGENCY.equals(appeal.getType())
+                || appeal.getPolicyAssignmentId() == null) {
+            return null;
+        }
+
+        PolicyAssignment assignment =
+                policyAssignmentRepository
+                        .findByIdAndDeletedAtIsNull(appeal.getPolicyAssignmentId())
+                        .orElseThrow(
+                                () ->
+                                        new ApplicationException(
+                                                PolicyErrorCode.POLICY_ASSIGNMENT_NOT_FOUND));
+        Policy policy =
+                policyRepository
+                        .findByIdAndDeletedAtIsNull(assignment.getPolicyId())
+                        .orElseThrow(
+                                () -> new ApplicationException(PolicyErrorCode.POLICY_NOT_FOUND));
+        return policy.getPolicyType();
+    }
+
+    /** 요청자 ID 목록 추출 */
+    private Set<Long> extractRequesterIds(List<PolicyAppeal> appeals) {
+        return appeals.stream().map(PolicyAppeal::getRequesterId).collect(Collectors.toSet());
+    }
+
+    /** 고객 이름 일괄 조회 */
+    private Map<Long, String> loadCustomerNameMap(Set<Long> customerIds) {
+        if (customerIds.isEmpty()) {
+            return Map.of();
+        }
         return customerRepository.findAllById(customerIds).stream()
                 .collect(Collectors.toMap(Customer::getId, Customer::getName));
     }

--- a/src/main/java/com/project/domain/appeal/service/AppealServiceImpl.java
+++ b/src/main/java/com/project/domain/appeal/service/AppealServiceImpl.java
@@ -105,6 +105,11 @@ public class AppealServiceImpl implements AppealService {
         PolicyAppeal appeal = findAppealOrThrow(appealId);
         validateFamilyAccess(auth.familyId(), appeal);
 
+        // MEMBER에 대해서는 반드시 “본인 소유 appeal인지”까지 확인
+        if (!auth.isOwner() && !appeal.getRequesterId().equals(auth.customerId())) {
+            throw new ApplicationException(AppealErrorCode.APPEAL_FORBIDDEN);
+        }
+
         // 2. 댓글 size를 보정하고 커서 기반으로 댓글을 조회한다.
         int pageSize = normalizeSize(size);
         List<PolicyAppealComment> comments =
@@ -167,7 +172,10 @@ public class AppealServiceImpl implements AppealService {
             throw new ApplicationException(AppealErrorCode.APPEAL_FORBIDDEN);
         }
 
-        // 3. NORMAL/PENDING 상태의 이의제기를 저장한다.
+        // 3. 같은 정책에 대해 같은 요청자의 진행 중 이의제기가 이미 있는지 확인한다.
+        validateNoPendingAppeal(policyAssignment.getId(), auth.customerId());
+
+        // 4. NORMAL/PENDING 상태의 이의제기를 저장한다.
         PolicyAppeal appeal =
                 policyAppealRepository.save(
                         PolicyAppeal.builder()
@@ -179,7 +187,7 @@ public class AppealServiceImpl implements AppealService {
                                 .status(AppealStatus.PENDING)
                                 .build());
 
-        // 4. 생성 결과를 응답 모델로 반환한다.
+        // 5. 생성 결과를 응답 모델로 반환한다.
         return new AppealCreateResult(
                 appeal.getId(),
                 appeal.getPolicyAssignmentId(),
@@ -300,6 +308,20 @@ public class AppealServiceImpl implements AppealService {
     private void validateMemberOnly(AuthContext auth) {
         if (!RoleType.MEMBER.equals(auth.role())) {
             throw new ApplicationException(AppealErrorCode.APPEAL_FORBIDDEN);
+        }
+    }
+
+    /** 진행 중 이의제기 중복 여부 검증 */
+    private void validateNoPendingAppeal(Long policyAssignmentId, Long requesterId) {
+        boolean alreadyPending =
+                policyAppealRepository
+                        .existsByPolicyAssignmentIdAndRequesterIdAndTypeAndStatusAndDeletedAtIsNull(
+                                policyAssignmentId,
+                                requesterId,
+                                AppealType.NORMAL,
+                                AppealStatus.PENDING);
+        if (alreadyPending) {
+            throw new ApplicationException(AppealErrorCode.APPEAL_ALREADY_PENDING);
         }
     }
 

--- a/src/main/java/com/project/domain/appeal/service/AppealServiceImpl.java
+++ b/src/main/java/com/project/domain/appeal/service/AppealServiceImpl.java
@@ -2,14 +2,13 @@ package com.project.domain.appeal.service;
 
 import java.time.Clock;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.YearMonth;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -107,23 +106,23 @@ public class AppealServiceImpl implements AppealService {
         PolicyAppeal appeal = findAppealOrThrow(appealId);
         validateFamilyAccess(auth.familyId(), appeal);
 
-        // MEMBER에 대해서는 반드시 “본인 소유 appeal인지”까지 확인
+        // 2. MEMBER에 대해서는 반드시 본인 소유 appeal인지까지 확인한다.
         if (!auth.isOwner() && !appeal.getRequesterId().equals(auth.customerId())) {
             throw new ApplicationException(AppealErrorCode.APPEAL_FORBIDDEN);
         }
 
-        // 2. 댓글 size를 보정하고 커서 기반으로 댓글을 조회한다.
+        // 3. 댓글 size를 보정하고 커서 기반으로 댓글을 조회한다.
         int pageSize = normalizeSize(size);
         List<PolicyAppealComment> comments =
                 policyAppealCommentRepository.findByAppealIdAndIdLessThanOrderByIdDesc(
                         appealId, cursor, PageRequest.of(0, pageSize + 1));
 
-        // 3. pageSize + 1 조회 결과로 댓글 nextCursor와 hasNext를 계산한다.
+        // 4. pageSize + 1 조회 결과로 댓글 nextCursor와 hasNext를 계산한다.
         boolean hasNext = comments.size() > pageSize;
         List<PolicyAppealComment> page = hasNext ? comments.subList(0, pageSize) : comments;
         String nextCursor = hasNext ? String.valueOf(page.getLast().getId()) : null;
 
-        // 4. 요청자, 처리자, 댓글 작성자 이름과 정책 타입을 조회해 상세 응답으로 변환한다.
+        // 5. 요청자, 처리자, 댓글 작성자 이름과 정책 타입을 조회해 상세 응답으로 변환한다.
         Set<Long> customerIds = new HashSet<>();
         customerIds.add(appeal.getRequesterId());
         if (appeal.getResolvedById() != null) {
@@ -162,7 +161,7 @@ public class AppealServiceImpl implements AppealService {
         // 1. MEMBER 역할만 일반 이의제기를 생성할 수 있다.
         validateMemberOnly(auth);
 
-        // 2. 정책 할당이 존재하고 같은 가족 소속인지 확인한다.
+        // 2. 정책 할당이 존재하고 같은 가족 소속인지, 본인 대상인지 확인한다.
         PolicyAssignment policyAssignment =
                 policyAssignmentRepository
                         .findByIdAndDeletedAtIsNull(request.policyAssignmentId())
@@ -170,8 +169,8 @@ public class AppealServiceImpl implements AppealService {
                                 () ->
                                         new ApplicationException(
                                                 PolicyErrorCode.POLICY_ASSIGNMENT_NOT_FOUND));
-        // 2-1. 같은 가족 소속인지 + 로그인한 사용자 본인의 policyAssigment인지 체크
-        if (!policyAssignment.getFamilyId().equals(auth.familyId()) || !policyAssignment.getTargetCustomerId().equals(auth.customerId())) {
+        if (!policyAssignment.getFamilyId().equals(auth.familyId())
+                || !policyAssignment.getTargetCustomerId().equals(auth.customerId())) {
             throw new ApplicationException(AppealErrorCode.APPEAL_FORBIDDEN);
         }
 
@@ -208,47 +207,40 @@ public class AppealServiceImpl implements AppealService {
         validateMemberOnly(auth);
         validateEmergencyBytes(request.additionalBytes());
 
-        // 2. 현재 월에 승인된 긴급 요청이 이미 있는지 확인한다.
-        LocalDateTime monthStart = YearMonth.now(clock).atDay(1).atStartOfDay();
-        LocalDateTime monthEnd = YearMonth.now(clock).atEndOfMonth().atTime(23, 59, 59);
-        boolean alreadyApproved =
-                !policyAppealRepository
-                        .findByRequesterIdAndTypeAndStatusAndCreatedAtBetween(
-                                auth.customerId(),
-                                AppealType.EMERGENCY,
-                                AppealStatus.APPROVED,
-                                monthStart,
-                                monthEnd)
-                        .isEmpty();
-        if (alreadyApproved) {
-            throw new ApplicationException(AppealErrorCode.APPEAL_EMERGENCY_MONTHLY_LIMIT);
-        }
-
-        // 3. 당월 고객 쿼터를 조회하고 무제한 사용자 여부를 확인한다.
+        // 2. 당월 고객 쿼터를 조회하고 무제한 사용자 여부를 확인한다.
+        LocalDate currentMonth = LocalDate.now(clock).withDayOfMonth(1);
         CustomerQuota customerQuota =
                 customerQuotaRepository
                         .findByFamilyIdAndCustomerIdAndCurrentMonthAndDeletedAtIsNull(
-                                auth.familyId(),
-                                auth.customerId(),
-                                LocalDate.now(clock).withDayOfMonth(1))
+                                auth.familyId(), auth.customerId(), currentMonth)
                         .orElseThrow(
                                 () ->
                                         new ApplicationException(
                                                 CustomerErrorCode.CUSTOMER_NOT_FOUND));
+
         if (customerQuota.getMonthlyLimitBytes() == null) {
             throw new ApplicationException(AppealErrorCode.APPEAL_EMERGENCY_UNLIMITED);
         }
 
-        // 4. APPROVED 상태의 긴급 이의제기를 저장하고 월 한도를 즉시 증가시킨다.
-        PolicyAppeal appeal =
-                policyAppealRepository.save(
-                        PolicyAppeal.builder()
-                                .type(AppealType.EMERGENCY)
-                                .requesterId(auth.customerId())
-                                .requestReason(request.requestReason())
-                                .desiredRules(Map.of("additionalBytes", request.additionalBytes()))
-                                .status(AppealStatus.APPROVED)
-                                .build());
+        // 3. DB unique 제약으로 같은 사용자의 당월 긴급 승인을 단일화한다.
+        PolicyAppeal appeal;
+        try {
+            appeal =
+                    policyAppealRepository.saveAndFlush(
+                            PolicyAppeal.builder()
+                                    .type(AppealType.EMERGENCY)
+                                    .requesterId(auth.customerId())
+                                    .requestReason(request.requestReason())
+                                    .desiredRules(
+                                            Map.of("additionalBytes", request.additionalBytes()))
+                                    .status(AppealStatus.APPROVED)
+                                    .emergencyGrantMonth(currentMonth)
+                                    .build());
+        } catch (DataIntegrityViolationException e) {
+            throw new ApplicationException(AppealErrorCode.APPEAL_EMERGENCY_MONTHLY_LIMIT);
+        }
+
+        // 4. 승인 저장이 확정되면 월 한도를 즉시 증가시킨다.
         customerQuota.addMonthlyLimitBytes(request.additionalBytes());
 
         // 5. 긴급 쿼터 결과를 응답 모델로 반환한다.

--- a/src/main/java/com/project/domain/appeal/service/AppealServiceImpl.java
+++ b/src/main/java/com/project/domain/appeal/service/AppealServiceImpl.java
@@ -1,5 +1,6 @@
 package com.project.domain.appeal.service;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
@@ -57,6 +58,7 @@ public class AppealServiceImpl implements AppealService {
     private static final long MIN_EMERGENCY_BYTES = 104_857_600L;
     private static final long MAX_EMERGENCY_BYTES = 314_572_800L;
 
+    private final Clock clock;
     private final PolicyAppealRepository policyAppealRepository;
     private final PolicyAppealCommentRepository policyAppealCommentRepository;
     private final CustomerRepository customerRepository;
@@ -168,7 +170,8 @@ public class AppealServiceImpl implements AppealService {
                                 () ->
                                         new ApplicationException(
                                                 PolicyErrorCode.POLICY_ASSIGNMENT_NOT_FOUND));
-        if (!policyAssignment.getFamilyId().equals(auth.familyId())) {
+        // 2-1. 같은 가족 소속인지 + 로그인한 사용자 본인의 policyAssigment인지 체크
+        if (!policyAssignment.getFamilyId().equals(auth.familyId()) || !policyAssignment.getTargetCustomerId().equals(auth.customerId())) {
             throw new ApplicationException(AppealErrorCode.APPEAL_FORBIDDEN);
         }
 
@@ -206,8 +209,8 @@ public class AppealServiceImpl implements AppealService {
         validateEmergencyBytes(request.additionalBytes());
 
         // 2. 현재 월에 승인된 긴급 요청이 이미 있는지 확인한다.
-        LocalDateTime monthStart = YearMonth.now().atDay(1).atStartOfDay();
-        LocalDateTime monthEnd = YearMonth.now().atEndOfMonth().atTime(23, 59, 59);
+        LocalDateTime monthStart = YearMonth.now(clock).atDay(1).atStartOfDay();
+        LocalDateTime monthEnd = YearMonth.now(clock).atEndOfMonth().atTime(23, 59, 59);
         boolean alreadyApproved =
                 !policyAppealRepository
                         .findByRequesterIdAndTypeAndStatusAndCreatedAtBetween(
@@ -227,7 +230,7 @@ public class AppealServiceImpl implements AppealService {
                         .findByFamilyIdAndCustomerIdAndCurrentMonthAndDeletedAtIsNull(
                                 auth.familyId(),
                                 auth.customerId(),
-                                LocalDate.now().withDayOfMonth(1))
+                                LocalDate.now(clock).withDayOfMonth(1))
                         .orElseThrow(
                                 () ->
                                         new ApplicationException(

--- a/src/main/java/com/project/domain/customer/entity/CustomerQuota.java
+++ b/src/main/java/com/project/domain/customer/entity/CustomerQuota.java
@@ -71,4 +71,8 @@ public class CustomerQuota extends BaseEntity {
         this.isBlocked = isBlocked;
         this.blockReason = blockReason;
     }
+
+    public void addMonthlyLimitBytes(long additionalBytes) {
+        this.monthlyLimitBytes += additionalBytes;
+    }
 }

--- a/src/main/java/com/project/domain/customer/repository/CustomerQuotaRepository.java
+++ b/src/main/java/com/project/domain/customer/repository/CustomerQuotaRepository.java
@@ -1,7 +1,13 @@
 package com.project.domain.customer.repository;
 
+import java.time.LocalDate;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.project.domain.customer.entity.CustomerQuota;
 
-public interface CustomerQuotaRepository extends JpaRepository<CustomerQuota, Long> {}
+public interface CustomerQuotaRepository extends JpaRepository<CustomerQuota, Long> {
+    Optional<CustomerQuota> findByFamilyIdAndCustomerIdAndCurrentMonthAndDeletedAtIsNull(
+            Long familyId, Long customerId, LocalDate currentMonth);
+}

--- a/src/main/java/com/project/domain/policy/repository/PolicyAssignmentRepository.java
+++ b/src/main/java/com/project/domain/policy/repository/PolicyAssignmentRepository.java
@@ -12,6 +12,8 @@ import com.project.domain.policy.entity.PolicyAssignment;
 import com.project.domain.policy.enums.PolicyType;
 
 public interface PolicyAssignmentRepository extends JpaRepository<PolicyAssignment, Long> {
+    Optional<PolicyAssignment> findByIdAndDeletedAtIsNull(Long id);
+
     @Query(
             "SELECT p FROM PolicyAssignment p WHERE p.familyId = :familyId AND p.deletedAt"
                     + " IS NULL")

--- a/src/main/java/com/project/domain/reward/service/RewardServiceImpl.java
+++ b/src/main/java/com/project/domain/reward/service/RewardServiceImpl.java
@@ -1,5 +1,6 @@
 package com.project.domain.reward.service;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +44,7 @@ public class RewardServiceImpl implements RewardService {
     private static final int MAX_CURSOR_SIZE = 100;
     private static final String UNKNOWN_NAME = "unknown";
 
+    private final Clock clock;
     private final MissionRequestRepository missionRequestRepository;
     private final MissionItemRepository missionItemRepository;
     private final MissionLogRepository missionLogRepository;
@@ -80,8 +82,9 @@ public class RewardServiceImpl implements RewardService {
             if (!mission.canComplete()) {
                 throw new ApplicationException(MissionErrorCode.MISSION_INVALID_STATUS_TRANSITION);
             }
-            missionRequest.approve(auth.customerId(), LocalDateTime.now());
-            mission.complete(LocalDateTime.now());
+            LocalDateTime now = LocalDateTime.now(clock);
+            missionRequest.approve(auth.customerId(), now);
+            mission.complete(now);
             appendLog(
                     mission.getId(),
                     auth.customerId(),
@@ -91,7 +94,7 @@ public class RewardServiceImpl implements RewardService {
             if (req.rejectReason() == null || req.rejectReason().isBlank()) {
                 throw new ApplicationException(MissionErrorCode.MISSION_REJECT_REASON_REQUIRED);
             }
-            missionRequest.reject(auth.customerId(), req.rejectReason(), LocalDateTime.now());
+            missionRequest.reject(auth.customerId(), req.rejectReason(), LocalDateTime.now(clock));
             appendLog(
                     mission.getId(),
                     auth.customerId(),

--- a/src/main/java/com/project/global/config/TimeConfig.java
+++ b/src/main/java/com/project/global/config/TimeConfig.java
@@ -1,0 +1,18 @@
+package com.project.global.config;
+
+import java.time.Clock;
+import java.time.ZoneId;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeConfig {
+
+    private static final ZoneId ASIA_SEOUL = ZoneId.of("Asia/Seoul");
+
+    @Bean
+    public Clock clock() {
+        return Clock.system(ASIA_SEOUL);
+    }
+}

--- a/src/main/java/com/project/global/exception/code/AppealErrorCode.java
+++ b/src/main/java/com/project/global/exception/code/AppealErrorCode.java
@@ -21,7 +21,9 @@ public enum AppealErrorCode implements BaseErrorCode {
     APPEAL_CANCEL_FORBIDDEN(HttpStatus.FORBIDDEN, "APPEAL_008", "본인이 생성한 이의제기만 취소할 수 있습니다."),
     APPEAL_NOT_CANCELLABLE(HttpStatus.CONFLICT, "APPEAL_009", "취소할 수 없는 상태입니다."),
     APPEAL_EMERGENCY_CANCEL_NOT_ALLOWED(
-            HttpStatus.BAD_REQUEST, "APPEAL_010", "EMERGENCY 타입은 취소할 수 없습니다.");
+            HttpStatus.BAD_REQUEST, "APPEAL_010", "EMERGENCY 타입은 취소할 수 없습니다."),
+    APPEAL_ALREADY_PENDING(
+            HttpStatus.CONFLICT, "APPEAL_011", "같은 정책에 대해 진행 중인 이의제기가 이미 존재합니다.");
 
     private final HttpStatus httpStatus;
     private final String customCode;

--- a/src/main/java/com/project/global/exception/code/AppealErrorCode.java
+++ b/src/main/java/com/project/global/exception/code/AppealErrorCode.java
@@ -22,8 +22,7 @@ public enum AppealErrorCode implements BaseErrorCode {
     APPEAL_NOT_CANCELLABLE(HttpStatus.CONFLICT, "APPEAL_009", "취소할 수 없는 상태입니다."),
     APPEAL_EMERGENCY_CANCEL_NOT_ALLOWED(
             HttpStatus.BAD_REQUEST, "APPEAL_010", "EMERGENCY 타입은 취소할 수 없습니다."),
-    APPEAL_ALREADY_PENDING(
-            HttpStatus.CONFLICT, "APPEAL_011", "같은 정책에 대해 진행 중인 이의제기가 이미 존재합니다.");
+    APPEAL_ALREADY_PENDING(HttpStatus.CONFLICT, "APPEAL_011", "같은 정책에 대해 진행 중인 이의제기가 이미 존재합니다.");
 
     private final HttpStatus httpStatus;
     private final String customCode;

--- a/src/main/java/com/project/global/exception/code/AppealErrorCode.java
+++ b/src/main/java/com/project/global/exception/code/AppealErrorCode.java
@@ -1,0 +1,29 @@
+package com.project.global.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AppealErrorCode implements BaseErrorCode {
+    APPEAL_NOT_FOUND(HttpStatus.NOT_FOUND, "APPEAL_001", "이의제기를 찾을 수 없습니다."),
+    APPEAL_ALREADY_RESOLVED(HttpStatus.CONFLICT, "APPEAL_002", "이미 처리된 이의제기입니다."),
+    APPEAL_FORBIDDEN(HttpStatus.FORBIDDEN, "APPEAL_003", "이의제기에 접근할 권한이 없습니다."),
+    APPEAL_INVALID_DESIRED_RULES(
+            HttpStatus.BAD_REQUEST, "APPEAL_004", "desiredRules 형식이 정책 유형과 맞지 않습니다."),
+    APPEAL_EMERGENCY_MONTHLY_LIMIT(
+            HttpStatus.TOO_MANY_REQUESTS, "APPEAL_005", "이번 달 긴급 요청을 이미 사용했습니다."),
+    APPEAL_EMERGENCY_INVALID_BYTES(HttpStatus.BAD_REQUEST, "APPEAL_006", "요청 바이트가 허용 범위를 벗어났습니다."),
+    APPEAL_EMERGENCY_UNLIMITED(
+            HttpStatus.BAD_REQUEST, "APPEAL_007", "무제한 쿼터 사용자는 긴급 요청을 할 수 없습니다."),
+    APPEAL_CANCEL_FORBIDDEN(HttpStatus.FORBIDDEN, "APPEAL_008", "본인이 생성한 이의제기만 취소할 수 있습니다."),
+    APPEAL_NOT_CANCELLABLE(HttpStatus.CONFLICT, "APPEAL_009", "취소할 수 없는 상태입니다."),
+    APPEAL_EMERGENCY_CANCEL_NOT_ALLOWED(
+            HttpStatus.BAD_REQUEST, "APPEAL_010", "EMERGENCY 타입은 취소할 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String customCode;
+    private final String message;
+}

--- a/src/test/java/com/project/domain/appeal/service/AppealServiceImplTest.java
+++ b/src/test/java/com/project/domain/appeal/service/AppealServiceImplTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 
 import com.project.domain.appeal.dto.request.AppealCreateRequest;
@@ -279,15 +280,11 @@ class AppealServiceImplTest {
         setCreatedAt(saved, LocalDateTime.of(2026, 3, 10, 12, 0));
 
         given(
-                        policyAppealRepository.findByRequesterIdAndTypeAndStatusAndCreatedAtBetween(
-                                any(), any(), any(), any(), any()))
-                .willReturn(List.of());
-        given(
                         customerQuotaRepository
                                 .findByFamilyIdAndCustomerIdAndCurrentMonthAndDeletedAtIsNull(
                                         10L, 2L, LocalDate.now(FIXED_CLOCK).withDayOfMonth(1)))
                 .willReturn(java.util.Optional.of(customerQuota));
-        given(policyAppealRepository.save(any(PolicyAppeal.class))).willReturn(saved);
+        given(policyAppealRepository.saveAndFlush(any(PolicyAppeal.class))).willReturn(saved);
 
         EmergencyQuotaResult result = appealService.requestEmergencyQuota(auth, request);
 
@@ -303,11 +300,23 @@ class AppealServiceImplTest {
     void requestEmergencyQuota_whenAlreadyApprovedThisMonth_thenThrowsLimit() {
         AuthContext auth = new AuthContext(2L, 10L, RoleType.MEMBER);
         EmergencyQuotaRequest request = new EmergencyQuotaRequest("데이터가 부족합니다", 104_857_600L);
+        CustomerQuota customerQuota =
+                CustomerQuota.builder()
+                        .familyId(10L)
+                        .customerId(2L)
+                        .monthlyLimitBytes(500_000_000L)
+                        .monthlyUsedBytes(100L)
+                        .currentMonth(LocalDate.now(FIXED_CLOCK).withDayOfMonth(1))
+                        .isBlocked(false)
+                        .build();
 
         given(
-                        policyAppealRepository.findByRequesterIdAndTypeAndStatusAndCreatedAtBetween(
-                                any(), any(), any(), any(), any()))
-                .willReturn(List.of(appeal(70L, 2L, null, AppealStatus.APPROVED)));
+                        customerQuotaRepository
+                                .findByFamilyIdAndCustomerIdAndCurrentMonthAndDeletedAtIsNull(
+                                        10L, 2L, LocalDate.now(FIXED_CLOCK).withDayOfMonth(1)))
+                .willReturn(java.util.Optional.of(customerQuota));
+        given(policyAppealRepository.saveAndFlush(any(PolicyAppeal.class)))
+                .willThrow(new DataIntegrityViolationException("duplicate emergency grant month"));
 
         assertThatThrownBy(() -> appealService.requestEmergencyQuota(auth, request))
                 .isInstanceOf(ApplicationException.class)

--- a/src/test/java/com/project/domain/appeal/service/AppealServiceImplTest.java
+++ b/src/test/java/com/project/domain/appeal/service/AppealServiceImplTest.java
@@ -1,10 +1,13 @@
 package com.project.domain.appeal.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyIterable;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -17,27 +20,58 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageRequest;
 
+import com.project.domain.appeal.dto.request.AppealCreateRequest;
+import com.project.domain.appeal.dto.request.EmergencyQuotaRequest;
 import com.project.domain.appeal.entity.PolicyAppeal;
+import com.project.domain.appeal.entity.PolicyAppealComment;
 import com.project.domain.appeal.enums.AppealStatus;
 import com.project.domain.appeal.enums.AppealType;
+import com.project.domain.appeal.model.AppealCreateResult;
+import com.project.domain.appeal.model.AppealDetailResult;
 import com.project.domain.appeal.model.AppealListResult;
+import com.project.domain.appeal.model.EmergencyQuotaResult;
+import com.project.domain.appeal.repository.PolicyAppealCommentRepository;
 import com.project.domain.appeal.repository.PolicyAppealRepository;
 import com.project.domain.customer.entity.Customer;
+import com.project.domain.customer.entity.CustomerQuota;
 import com.project.domain.customer.enums.RoleType;
+import com.project.domain.customer.repository.CustomerQuotaRepository;
 import com.project.domain.customer.repository.CustomerRepository;
+import com.project.domain.family.entity.FamilyMember;
+import com.project.domain.family.repository.FamilyMemberRepository;
+import com.project.domain.policy.entity.Policy;
+import com.project.domain.policy.entity.PolicyAssignment;
+import com.project.domain.policy.enums.PolicyType;
+import com.project.domain.policy.repository.PolicyAssignmentRepository;
+import com.project.domain.policy.repository.PolicyRepository;
 import com.project.global.auth.model.AuthContext;
+import com.project.global.exception.ApplicationException;
+import com.project.global.exception.code.AppealErrorCode;
 
 @ExtendWith(MockitoExtension.class)
 class AppealServiceImplTest {
 
     @Mock private PolicyAppealRepository policyAppealRepository;
+    @Mock private PolicyAppealCommentRepository policyAppealCommentRepository;
     @Mock private CustomerRepository customerRepository;
+    @Mock private FamilyMemberRepository familyMemberRepository;
+    @Mock private PolicyAssignmentRepository policyAssignmentRepository;
+    @Mock private PolicyRepository policyRepository;
+    @Mock private CustomerQuotaRepository customerQuotaRepository;
 
     private AppealServiceImpl appealService;
 
     @BeforeEach
     void setUp() {
-        appealService = new AppealServiceImpl(policyAppealRepository, customerRepository);
+        appealService =
+                new AppealServiceImpl(
+                        policyAppealRepository,
+                        policyAppealCommentRepository,
+                        customerRepository,
+                        familyMemberRepository,
+                        policyAssignmentRepository,
+                        policyRepository,
+                        customerQuotaRepository);
     }
 
     @Test
@@ -102,12 +136,156 @@ class AppealServiceImplTest {
         assertThat(result.nextCursor()).isEqualTo("39");
     }
 
+    @Test
+    @DisplayName("상세 조회는 같은 가족의 댓글 커서 페이지와 정책 타입을 반환한다")
+    void getAppealDetail_whenSameFamily_thenReturnsDetail() {
+        AuthContext auth = new AuthContext(1L, 10L, RoleType.OWNER);
+        PolicyAppeal appeal = appeal(30L, 2L, 100L, AppealStatus.PENDING);
+        PolicyAppealComment firstComment = comment(20L, 2L, "첫 댓글");
+        PolicyAppealComment secondComment = comment(19L, 1L, "둘째 댓글");
+        PolicyAppealComment thirdComment = comment(18L, 2L, "셋째 댓글");
+
+        given(policyAppealRepository.findByIdAndDeletedAtIsNull(30L))
+                .willReturn(java.util.Optional.of(appeal));
+        given(familyMemberRepository.findByCustomerId(2L))
+                .willReturn(
+                        java.util.Optional.of(
+                                FamilyMember.builder()
+                                        .familyId(10L)
+                                        .customerId(2L)
+                                        .role(RoleType.MEMBER)
+                                        .build()));
+        given(
+                        policyAppealCommentRepository.findByAppealIdAndIdLessThanOrderByIdDesc(
+                                30L, null, PageRequest.of(0, 3)))
+                .willReturn(List.of(firstComment, secondComment, thirdComment));
+        given(policyAssignmentRepository.findByIdAndDeletedAtIsNull(100L))
+                .willReturn(java.util.Optional.of(policyAssignment(100L, 50L, 10L, 2L)));
+        given(policyRepository.findByIdAndDeletedAtIsNull(50L))
+                .willReturn(java.util.Optional.of(policy(50L, PolicyType.MONTHLY_LIMIT)));
+        given(customerRepository.findAllById(anyIterable()))
+                .willReturn(List.of(customer(1L, "owner"), customer(2L, "member")));
+
+        AppealDetailResult result = appealService.getAppealDetail(auth, 30L, null, 2);
+
+        assertThat(result.policyType()).isEqualTo(PolicyType.MONTHLY_LIMIT);
+        assertThat(result.comments().content()).hasSize(2);
+        assertThat(result.comments().hasNext()).isTrue();
+        assertThat(result.comments().nextCursor()).isEqualTo("19");
+        assertThat(result.comments().content().getFirst().authorName()).isEqualTo("member");
+    }
+
+    @Test
+    @DisplayName("MEMBER는 같은 가족 정책 할당으로 이의제기를 생성한다")
+    void createAppeal_whenMember_thenCreatesAppeal() {
+        AuthContext auth = new AuthContext(2L, 10L, RoleType.MEMBER);
+        AppealCreateRequest request =
+                new AppealCreateRequest(100L, "규칙 변경 요청", Map.of("limitBytes", 2048L));
+        PolicyAssignment assignment = policyAssignment(100L, 50L, 10L, 2L);
+        PolicyAppeal saved =
+                PolicyAppeal.builder()
+                        .id(40L)
+                        .type(AppealType.NORMAL)
+                        .policyAssignmentId(100L)
+                        .requesterId(2L)
+                        .requestReason("규칙 변경 요청")
+                        .desiredRules(Map.of("limitBytes", 2048L))
+                        .status(AppealStatus.PENDING)
+                        .build();
+        setCreatedAt(saved, LocalDateTime.of(2026, 3, 10, 10, 0));
+
+        given(policyAssignmentRepository.findByIdAndDeletedAtIsNull(100L))
+                .willReturn(java.util.Optional.of(assignment));
+        given(policyAppealRepository.save(any(PolicyAppeal.class))).willReturn(saved);
+
+        AppealCreateResult result = appealService.createAppeal(auth, request);
+
+        assertThat(result.appealId()).isEqualTo(40L);
+        assertThat(result.policyAssignmentId()).isEqualTo(100L);
+        assertThat(result.status()).isEqualTo(AppealStatus.PENDING);
+        assertThat(result.desiredRules()).containsEntry("limitBytes", 2048L);
+    }
+
+    @Test
+    @DisplayName("OWNER는 일반 이의제기를 생성할 수 없다")
+    void createAppeal_whenOwner_thenThrowsForbidden() {
+        AuthContext auth = new AuthContext(1L, 10L, RoleType.OWNER);
+        AppealCreateRequest request = new AppealCreateRequest(100L, "규칙 변경 요청", null);
+
+        assertThatThrownBy(() -> appealService.createAppeal(auth, request))
+                .isInstanceOf(ApplicationException.class)
+                .extracting(ex -> ((ApplicationException) ex).getCode())
+                .isEqualTo(AppealErrorCode.APPEAL_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("긴급 쿼터 요청은 월 한도를 즉시 증가시키고 승인 상태로 저장한다")
+    void requestEmergencyQuota_whenValid_thenUpdatesQuota() {
+        AuthContext auth = new AuthContext(2L, 10L, RoleType.MEMBER);
+        EmergencyQuotaRequest request = new EmergencyQuotaRequest("데이터가 부족합니다", 104_857_600L);
+        CustomerQuota customerQuota =
+                CustomerQuota.builder()
+                        .familyId(10L)
+                        .customerId(2L)
+                        .monthlyLimitBytes(500_000_000L)
+                        .monthlyUsedBytes(100L)
+                        .currentMonth(LocalDate.now().withDayOfMonth(1))
+                        .isBlocked(false)
+                        .build();
+        PolicyAppeal saved =
+                PolicyAppeal.builder()
+                        .id(55L)
+                        .type(AppealType.EMERGENCY)
+                        .requesterId(2L)
+                        .requestReason("데이터가 부족합니다")
+                        .desiredRules(Map.of("additionalBytes", 104_857_600L))
+                        .status(AppealStatus.APPROVED)
+                        .build();
+        setCreatedAt(saved, LocalDateTime.of(2026, 3, 10, 12, 0));
+
+        given(
+                        policyAppealRepository.findByRequesterIdAndTypeAndStatusAndCreatedAtBetween(
+                                any(), any(), any(), any(), any()))
+                .willReturn(List.of());
+        given(
+                        customerQuotaRepository
+                                .findByFamilyIdAndCustomerIdAndCurrentMonthAndDeletedAtIsNull(
+                                        10L, 2L, LocalDate.now().withDayOfMonth(1)))
+                .willReturn(java.util.Optional.of(customerQuota));
+        given(policyAppealRepository.save(any(PolicyAppeal.class))).willReturn(saved);
+
+        EmergencyQuotaResult result = appealService.requestEmergencyQuota(auth, request);
+
+        assertThat(result.appealId()).isEqualTo(55L);
+        assertThat(result.status()).isEqualTo(AppealStatus.APPROVED);
+        assertThat(result.additionalBytes()).isEqualTo(104_857_600L);
+        assertThat(result.newMonthlyLimitBytes()).isEqualTo(604_857_600L);
+        assertThat(customerQuota.getMonthlyLimitBytes()).isEqualTo(604_857_600L);
+    }
+
+    @Test
+    @DisplayName("이번 달 승인된 긴급 요청이 있으면 재요청을 거절한다")
+    void requestEmergencyQuota_whenAlreadyApprovedThisMonth_thenThrowsLimit() {
+        AuthContext auth = new AuthContext(2L, 10L, RoleType.MEMBER);
+        EmergencyQuotaRequest request = new EmergencyQuotaRequest("데이터가 부족합니다", 104_857_600L);
+
+        given(
+                        policyAppealRepository.findByRequesterIdAndTypeAndStatusAndCreatedAtBetween(
+                                any(), any(), any(), any(), any()))
+                .willReturn(List.of(appeal(70L, 2L, null, AppealStatus.APPROVED)));
+
+        assertThatThrownBy(() -> appealService.requestEmergencyQuota(auth, request))
+                .isInstanceOf(ApplicationException.class)
+                .extracting(ex -> ((ApplicationException) ex).getCode())
+                .isEqualTo(AppealErrorCode.APPEAL_EMERGENCY_MONTHLY_LIMIT);
+    }
+
     private PolicyAppeal appeal(
             Long appealId, Long requesterId, Long policyAssignmentId, AppealStatus status) {
         PolicyAppeal appeal =
                 PolicyAppeal.builder()
                         .id(appealId)
-                        .type(AppealType.NORMAL)
+                        .type(policyAssignmentId == null ? AppealType.EMERGENCY : AppealType.NORMAL)
                         .policyAssignmentId(policyAssignmentId)
                         .requesterId(requesterId)
                         .requestReason("need change")
@@ -116,6 +294,44 @@ class AppealServiceImplTest {
                         .build();
         setCreatedAt(appeal, LocalDateTime.of(2026, 3, 10, 10, 0));
         return appeal;
+    }
+
+    private PolicyAppealComment comment(Long commentId, Long authorId, String text) {
+        PolicyAppealComment comment =
+                PolicyAppealComment.builder()
+                        .id(commentId)
+                        .appealId(30L)
+                        .authorId(authorId)
+                        .comment(text)
+                        .build();
+        setField(
+                comment,
+                comment.getClass().getSuperclass(),
+                "createdAt",
+                LocalDateTime.of(2026, 3, 10, 11, 0));
+        return comment;
+    }
+
+    private PolicyAssignment policyAssignment(
+            Long assignmentId, Long policyId, Long familyId, Long targetCustomerId) {
+        return PolicyAssignment.builder()
+                .id(assignmentId)
+                .policyId(policyId)
+                .familyId(familyId)
+                .targetCustomerId(targetCustomerId)
+                .rules("{\"limitBytes\":1024}")
+                .isActive(true)
+                .build();
+    }
+
+    private Policy policy(Long policyId, PolicyType policyType) {
+        return Policy.builder()
+                .id(policyId)
+                .name("월 한도")
+                .policyType(policyType)
+                .isSystem(true)
+                .isActive(true)
+                .build();
     }
 
     private Customer customer(Long customerId, String name) {

--- a/src/test/java/com/project/domain/appeal/service/AppealServiceImplTest.java
+++ b/src/test/java/com/project/domain/appeal/service/AppealServiceImplTest.java
@@ -7,8 +7,11 @@ import static org.mockito.ArgumentMatchers.anyIterable;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 
@@ -51,6 +54,10 @@ import com.project.global.exception.code.AppealErrorCode;
 @ExtendWith(MockitoExtension.class)
 class AppealServiceImplTest {
 
+    private static final ZoneId ASIA_SEOUL = ZoneId.of("Asia/Seoul");
+    private static final Clock FIXED_CLOCK =
+            Clock.fixed(Instant.parse("2026-03-11T00:00:00Z"), ASIA_SEOUL);
+
     @Mock private PolicyAppealRepository policyAppealRepository;
     @Mock private PolicyAppealCommentRepository policyAppealCommentRepository;
     @Mock private CustomerRepository customerRepository;
@@ -65,6 +72,7 @@ class AppealServiceImplTest {
     void setUp() {
         appealService =
                 new AppealServiceImpl(
+                        FIXED_CLOCK,
                         policyAppealRepository,
                         policyAppealCommentRepository,
                         customerRepository,
@@ -256,7 +264,7 @@ class AppealServiceImplTest {
                         .customerId(2L)
                         .monthlyLimitBytes(500_000_000L)
                         .monthlyUsedBytes(100L)
-                        .currentMonth(LocalDate.now().withDayOfMonth(1))
+                        .currentMonth(LocalDate.now(FIXED_CLOCK).withDayOfMonth(1))
                         .isBlocked(false)
                         .build();
         PolicyAppeal saved =
@@ -277,7 +285,7 @@ class AppealServiceImplTest {
         given(
                         customerQuotaRepository
                                 .findByFamilyIdAndCustomerIdAndCurrentMonthAndDeletedAtIsNull(
-                                        10L, 2L, LocalDate.now().withDayOfMonth(1)))
+                                        10L, 2L, LocalDate.now(FIXED_CLOCK).withDayOfMonth(1)))
                 .willReturn(java.util.Optional.of(customerQuota));
         given(policyAppealRepository.save(any(PolicyAppeal.class))).willReturn(saved);
 

--- a/src/test/java/com/project/domain/appeal/service/AppealServiceImplTest.java
+++ b/src/test/java/com/project/domain/appeal/service/AppealServiceImplTest.java
@@ -196,6 +196,11 @@ class AppealServiceImplTest {
 
         given(policyAssignmentRepository.findByIdAndDeletedAtIsNull(100L))
                 .willReturn(java.util.Optional.of(assignment));
+        given(
+                        policyAppealRepository
+                                .existsByPolicyAssignmentIdAndRequesterIdAndTypeAndStatusAndDeletedAtIsNull(
+                                        100L, 2L, AppealType.NORMAL, AppealStatus.PENDING))
+                .willReturn(false);
         given(policyAppealRepository.save(any(PolicyAppeal.class))).willReturn(saved);
 
         AppealCreateResult result = appealService.createAppeal(auth, request);
@@ -216,6 +221,28 @@ class AppealServiceImplTest {
                 .isInstanceOf(ApplicationException.class)
                 .extracting(ex -> ((ApplicationException) ex).getCode())
                 .isEqualTo(AppealErrorCode.APPEAL_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("같은 정책에 대한 진행 중 이의제기가 있으면 생성할 수 없다")
+    void createAppeal_whenPendingAppealExists_thenThrowsConflict() {
+        AuthContext auth = new AuthContext(2L, 10L, RoleType.MEMBER);
+        AppealCreateRequest request =
+                new AppealCreateRequest(100L, "규칙 변경 요청", Map.of("limitBytes", 2048L));
+        PolicyAssignment assignment = policyAssignment(100L, 50L, 10L, 2L);
+
+        given(policyAssignmentRepository.findByIdAndDeletedAtIsNull(100L))
+                .willReturn(java.util.Optional.of(assignment));
+        given(
+                        policyAppealRepository
+                                .existsByPolicyAssignmentIdAndRequesterIdAndTypeAndStatusAndDeletedAtIsNull(
+                                        100L, 2L, AppealType.NORMAL, AppealStatus.PENDING))
+                .willReturn(true);
+
+        assertThatThrownBy(() -> appealService.createAppeal(auth, request))
+                .isInstanceOf(ApplicationException.class)
+                .extracting(ex -> ((ApplicationException) ex).getCode())
+                .isEqualTo(AppealErrorCode.APPEAL_ALREADY_PENDING);
     }
 
     @Test

--- a/src/test/java/com/project/domain/reward/service/RewardServiceImplTest.java
+++ b/src/test/java/com/project/domain/reward/service/RewardServiceImplTest.java
@@ -6,6 +6,10 @@ import static org.mockito.ArgumentMatchers.anyIterable;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 
@@ -37,6 +41,10 @@ import com.project.global.exception.code.MissionErrorCode;
 @ExtendWith(MockitoExtension.class)
 class RewardServiceImplTest {
 
+    private static final ZoneId ASIA_SEOUL = ZoneId.of("Asia/Seoul");
+    private static final Clock FIXED_CLOCK =
+            Clock.fixed(Instant.parse("2026-03-11T00:00:00Z"), ASIA_SEOUL);
+
     @Mock private MissionRequestRepository missionRequestRepository;
     @Mock private MissionItemRepository missionItemRepository;
     @Mock private MissionLogRepository missionLogRepository;
@@ -48,6 +56,7 @@ class RewardServiceImplTest {
     void setUp() {
         rewardService =
                 new RewardServiceImpl(
+                        FIXED_CLOCK,
                         missionRequestRepository,
                         missionItemRepository,
                         missionLogRepository,
@@ -119,7 +128,7 @@ class RewardServiceImplTest {
                         .requesterId(2L)
                         .status(MissionRequestStatus.APPROVED)
                         .resolvedById(1L)
-                        .resolvedAt(java.time.LocalDateTime.now())
+                        .resolvedAt(LocalDateTime.now(FIXED_CLOCK))
                         .build();
         given(
                         missionRequestRepository


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

<!-- 이슈 넘버와 티켓 넘버를 작성해주세요. 이슈가 닫히는 것을 원치 않으면 closed:를 지워주세요 -->

- closed: #
- jira: DABOM-xxx

---

## 🎯 목적

<!-- 왜 이 변경이 필요한지 배경과 목적을 작성해주세요. -->
- 기존 목록 조회 구조 위에 상세 응답, 생성 요청/응답, 긴급 쿼터 즉시 승인 로직을 연결한다.
- OWNER / MEMBER 권한 제약과 가족 범위 검증을 서비스 로직에서 명확히 드러내고, 커서 기반 댓글 조회와 월별 긴급 요청 제한을 함께 반영한다.

## 📝 변경 사항

<!-- 무엇을 변경했는지 리스트로 작성해주세요. -->
- `AppealController` 확장
  - `GET /appeals/{appealId}` 추가
  - `POST /appeals` 추가
  - `POST /appeals/emergency` 추가
- `AppealService`, `AppealServiceImpl` 확장
  - 이의제기 상세 조회 처리 추가
  - MEMBER 전용 일반 이의제기 생성 처리 추가
  - MEMBER 전용 긴급 쿼터 요청 처리 추가
- 상세 조회 지원용 모델/응답 추가
  - `AppealDetailResult`, `AppealDetailResponse`
  - 댓글 커서 페이지(`content`, `nextCursor`, `hasNext`) 응답 구조 추가
- 생성/긴급 요청 지원용 요청/응답 추가
  - `AppealCreateRequest`, `AppealCreateResponse`
  - `EmergencyQuotaRequest`, `EmergencyQuotaResponse`
  - `AppealCreateResult`, `EmergencyQuotaResult`
- 댓글 조회 지원용 엔티티/저장소 추가
  - `PolicyAppealComment`
  - `PolicyAppealCommentRepository`
- 저장소 보강
  - `PolicyAppealRepository.findByIdAndDeletedAtIsNull()`
  - `PolicyAppealRepository.findByRequesterIdAndTypeAndStatusAndCreatedAtBetween()`
  - `PolicyAssignmentRepository.findByIdAndDeletedAtIsNull()`
  - `CustomerQuotaRepository.findByFamilyIdAndCustomerIdAndCurrentMonthAndDeletedAtIsNull()`
- 에러 코드 추가
  - `AppealErrorCode` 정의
  - 접근 권한, 긴급 요청 범위, 월별 중복, 무제한 사용자 예외 반영
- `CustomerQuota`에 월 한도 증가 메서드 추가
- `AppealServiceImplTest` 확장
  - 상세 조회 성공
  - 일반 이의제기 생성 성공 / OWNER 차단
  - 긴급 쿼터 요청 성공 / 월별 중복 차단
-

## 📂 변경 범위

<!-- 변경된 도메인/레이어를 표시해주세요. 해당 항목에 [x]로 체크해주세요. -->


| 도메인 | controller | service | repository | entity | dto/model | global |
| :----: | :--------: | :-----: | :--------: | :----: | :-------: | :----: |
| appeal |     [x]    |   [x]   |    [x]     |  [x]   |    [x]    |  [x]   |
| policy |     [ ]    |   [ ]   |    [x]     |  [ ]   |    [ ]    |  [ ]   |
| customer |   [ ]    |   [ ]   |    [x]     |  [x]   |    [ ]    |  [ ]   |

---

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. 단순 변경이면 섹션을 지워도 됩니다. -->

```java
// # AppealServiceImpl 로직 소개
//
// 이의제기 상세 조회
// 1. 이의제기 존재 여부와 같은 가족 접근 가능 여부를 확인한다.
// 2. 댓글을 pageSize + 1로 조회해 nextCursor와 hasNext를 계산한다.
// 3. 요청자/처리자/댓글 작성자 이름을 일괄 조회한다.
// 4. NORMAL 이의제기는 policyAssignment -> policy를 따라 policyType을 계산한다.
// 5. 상세 정보와 댓글 페이지를 응답 모델로 변환한다.

// 이의제기 생성
// 1. MEMBER 역할만 생성 가능하도록 검증한다.
// 2. policyAssignmentId가 존재하고 같은 가족 소속인지 확인한다.
// 3. NORMAL / PENDING 상태의 이의제기를 저장한다.
// 4. 생성 응답 모델로 변환해 반환한다.

// 긴급 요청
// 1. MEMBER 역할과 additionalBytes 범위를 검증한다.
// 2. 이번 달 APPROVED EMERGENCY 이력이 있으면 거절한다.
// 3. 당월 CustomerQuota를 조회하고 무제한 사용자 여부를 검증한다.
// 4. APPROVED EMERGENCY 이의제기를 저장하고 monthlyLimitBytes를 즉시 증가시킨다.
// 5. 긴급 쿼터 응답 모델로 변환해 반환한다.
```

## 💬 리뷰어에게

<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
- 긴급 쿼터 요청을 `PolicyAppeal`의 `EMERGENCY + APPROVED` 레코드로 남기고 `desiredRules.additionalBytes`에 증액값을 저장하는 방향이 명세 의도와 맞는지 확인 부탁드립니다.
- 상세 조회에서 가족 범위 검증을 `appeal.requesterId -> FamilyMember.familyId` 기준으로 처리했는데, 현재 프로젝트의 접근 제어 패턴과 일관적인지 확인 부탁드립니다.
- 이번 범위에는 알림 발행과 AuditLog 저장을 포함하지 않았습니다. 관련 공통 인프라가 준비되면 후속 PR에서 연동하는 방향을 전제로 둔 구현입니다.

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [x] 전체 변경사항이 500줄을 넘지 않는가?

**코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → Repository → Entity`)
- [x] Setter 없이 비즈니스 메서드로 상태를 변경하는가?
- [x] `@Transactional`은 Service에만 선언했는가?

**테스트**
- [x] 신규 비즈니스 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

<!-- 추가로 공유할 내용이 있으면 작성해주세요. (관련 문서 링크, 후속 작업 등) -->
