### PR TITLE
[DABOM-287] 이의제기 승인/거절, 취소, 댓글 생성 API 구현

### DIFF
--- a/src/main/java/com/project/domain/appeal/controller/AppealController.java
+++ b/src/main/java/com/project/domain/appeal/controller/AppealController.java
@@ -14,8 +14,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.project.domain.appeal.dto.request.AppealCreateRequest;
 import com.project.domain.appeal.dto.request.AppealCommentRequest;
+import com.project.domain.appeal.dto.request.AppealCreateRequest;
 import com.project.domain.appeal.dto.request.AppealRespondRequest;
 import com.project.domain.appeal.dto.request.EmergencyQuotaRequest;
 import com.project.domain.appeal.dto.response.AppealCancelResponse;

--- a/src/main/java/com/project/domain/appeal/controller/AppealController.java
+++ b/src/main/java/com/project/domain/appeal/controller/AppealController.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Min;
 
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,19 +15,28 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.project.domain.appeal.dto.request.AppealCreateRequest;
+import com.project.domain.appeal.dto.request.AppealCommentRequest;
+import com.project.domain.appeal.dto.request.AppealRespondRequest;
 import com.project.domain.appeal.dto.request.EmergencyQuotaRequest;
+import com.project.domain.appeal.dto.response.AppealCancelResponse;
+import com.project.domain.appeal.dto.response.AppealCommentResponse;
 import com.project.domain.appeal.dto.response.AppealCreateResponse;
 import com.project.domain.appeal.dto.response.AppealDetailResponse;
 import com.project.domain.appeal.dto.response.AppealListResponse;
+import com.project.domain.appeal.dto.response.AppealRespondResponse;
 import com.project.domain.appeal.dto.response.EmergencyQuotaResponse;
 import com.project.domain.appeal.enums.AppealStatus;
+import com.project.domain.appeal.model.AppealCancelResult;
+import com.project.domain.appeal.model.AppealCommentResult;
 import com.project.domain.appeal.model.AppealCreateResult;
 import com.project.domain.appeal.model.AppealDetailResult;
 import com.project.domain.appeal.model.AppealListResult;
+import com.project.domain.appeal.model.AppealRespondResult;
 import com.project.domain.appeal.model.EmergencyQuotaResult;
 import com.project.domain.appeal.service.AppealService;
 import com.project.global.api.response.ApiResponse;
 import com.project.global.auth.aop.CustomerId;
+import com.project.global.auth.aop.OwnerOnly;
 import com.project.global.auth.model.AuthContext;
 import com.project.global.auth.service.AuthContextService;
 
@@ -82,6 +92,41 @@ public class AppealController {
         AuthContext auth = authContextService.resolve(customerId);
         AppealCreateResult result = appealService.createAppeal(auth, request);
         return ApiResponse.created(AppealCreateResponse.from(result));
+    }
+
+    /** 이의제기 승인/거절 처리 */
+    @OwnerOnly
+    @PatchMapping("/{appealId}/respond")
+    @Operation(summary = "이의제기 승인/거절")
+    public ApiResponse<AppealRespondResponse> respondAppeal(
+            @Parameter(hidden = true) @CustomerId Long customerId,
+            @PathVariable Long appealId,
+            @RequestBody @Valid AppealRespondRequest request) {
+        AuthContext auth = authContextService.resolve(customerId);
+        AppealRespondResult result = appealService.respondAppeal(auth, appealId, request);
+        return ApiResponse.success(AppealRespondResponse.from(result));
+    }
+
+    /** 이의제기 댓글 작성 처리 */
+    @PostMapping("/{appealId}/comments")
+    @Operation(summary = "이의제기 댓글 작성")
+    public ApiResponse<AppealCommentResponse> createComment(
+            @Parameter(hidden = true) @CustomerId Long customerId,
+            @PathVariable Long appealId,
+            @RequestBody @Valid AppealCommentRequest request) {
+        AuthContext auth = authContextService.resolve(customerId);
+        AppealCommentResult result = appealService.createComment(auth, appealId, request);
+        return ApiResponse.created(AppealCommentResponse.from(result));
+    }
+
+    /** 이의제기 취소 처리 */
+    @PatchMapping("/{appealId}/cancel")
+    @Operation(summary = "이의제기 취소")
+    public ApiResponse<AppealCancelResponse> cancelAppeal(
+            @Parameter(hidden = true) @CustomerId Long customerId, @PathVariable Long appealId) {
+        AuthContext auth = authContextService.resolve(customerId);
+        AppealCancelResult result = appealService.cancelAppeal(auth, appealId);
+        return ApiResponse.success(AppealCancelResponse.from(result));
     }
 
     /** 긴급 쿼터 요청 처리 */

--- a/src/main/java/com/project/domain/appeal/dto/request/AppealCommentRequest.java
+++ b/src/main/java/com/project/domain/appeal/dto/request/AppealCommentRequest.java
@@ -1,0 +1,5 @@
+package com.project.domain.appeal.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AppealCommentRequest(@NotBlank String comment) {}

--- a/src/main/java/com/project/domain/appeal/dto/request/AppealRespondRequest.java
+++ b/src/main/java/com/project/domain/appeal/dto/request/AppealRespondRequest.java
@@ -1,0 +1,5 @@
+package com.project.domain.appeal.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AppealRespondRequest(@NotBlank String action, String rejectReason) {}

--- a/src/main/java/com/project/domain/appeal/dto/response/AppealCancelResponse.java
+++ b/src/main/java/com/project/domain/appeal/dto/response/AppealCancelResponse.java
@@ -7,7 +7,6 @@ import com.project.domain.appeal.model.AppealCancelResult;
 
 public record AppealCancelResponse(Long appealId, AppealStatus status, LocalDateTime cancelledAt) {
     public static AppealCancelResponse from(AppealCancelResult result) {
-        return new AppealCancelResponse(
-                result.appealId(), result.status(), result.cancelledAt());
+        return new AppealCancelResponse(result.appealId(), result.status(), result.cancelledAt());
     }
 }

--- a/src/main/java/com/project/domain/appeal/dto/response/AppealCancelResponse.java
+++ b/src/main/java/com/project/domain/appeal/dto/response/AppealCancelResponse.java
@@ -1,0 +1,13 @@
+package com.project.domain.appeal.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.project.domain.appeal.enums.AppealStatus;
+import com.project.domain.appeal.model.AppealCancelResult;
+
+public record AppealCancelResponse(Long appealId, AppealStatus status, LocalDateTime cancelledAt) {
+    public static AppealCancelResponse from(AppealCancelResult result) {
+        return new AppealCancelResponse(
+                result.appealId(), result.status(), result.cancelledAt());
+    }
+}

--- a/src/main/java/com/project/domain/appeal/dto/response/AppealCommentResponse.java
+++ b/src/main/java/com/project/domain/appeal/dto/response/AppealCommentResponse.java
@@ -1,0 +1,17 @@
+package com.project.domain.appeal.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.project.domain.appeal.model.AppealCommentResult;
+
+public record AppealCommentResponse(
+        Long commentId, Long appealId, Long authorId, String comment, LocalDateTime createdAt) {
+    public static AppealCommentResponse from(AppealCommentResult result) {
+        return new AppealCommentResponse(
+                result.commentId(),
+                result.appealId(),
+                result.authorId(),
+                result.comment(),
+                result.createdAt());
+    }
+}

--- a/src/main/java/com/project/domain/appeal/dto/response/AppealCommentResponse.java
+++ b/src/main/java/com/project/domain/appeal/dto/response/AppealCommentResponse.java
@@ -5,12 +5,18 @@ import java.time.LocalDateTime;
 import com.project.domain.appeal.model.AppealCommentResult;
 
 public record AppealCommentResponse(
-        Long commentId, Long appealId, Long authorId, String comment, LocalDateTime createdAt) {
+        Long commentId,
+        Long appealId,
+        Long authorId,
+        String authorName,
+        String comment,
+        LocalDateTime createdAt) {
     public static AppealCommentResponse from(AppealCommentResult result) {
         return new AppealCommentResponse(
                 result.commentId(),
                 result.appealId(),
                 result.authorId(),
+                result.authorName(),
                 result.comment(),
                 result.createdAt());
     }

--- a/src/main/java/com/project/domain/appeal/dto/response/AppealRespondResponse.java
+++ b/src/main/java/com/project/domain/appeal/dto/response/AppealRespondResponse.java
@@ -1,0 +1,22 @@
+package com.project.domain.appeal.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.project.domain.appeal.enums.AppealStatus;
+import com.project.domain.appeal.model.AppealRespondResult;
+
+public record AppealRespondResponse(
+        Long appealId,
+        AppealStatus status,
+        String rejectReason,
+        Long resolvedById,
+        LocalDateTime resolvedAt) {
+    public static AppealRespondResponse from(AppealRespondResult result) {
+        return new AppealRespondResponse(
+                result.appealId(),
+                result.status(),
+                result.rejectReason(),
+                result.resolvedById(),
+                result.resolvedAt());
+    }
+}

--- a/src/main/java/com/project/domain/appeal/entity/PolicyAppeal.java
+++ b/src/main/java/com/project/domain/appeal/entity/PolicyAppeal.java
@@ -95,18 +95,17 @@ public class PolicyAppeal extends BaseEntity {
         this.status = AppealStatus.APPROVED;
         this.rejectReason = null;
         this.resolvedById = resolverId;
-        this.resolvedAt = resolvedAt == null ? LocalDateTime.now() : resolvedAt;
+        this.resolvedAt = resolvedAt;
     }
-
     public void reject(Long resolverId, String rejectReason, LocalDateTime resolvedAt) {
         this.status = AppealStatus.REJECTED;
         this.rejectReason = rejectReason;
         this.resolvedById = resolverId;
-        this.resolvedAt = resolvedAt == null ? LocalDateTime.now() : resolvedAt;
+        this.resolvedAt = resolvedAt;
     }
-
     public void cancel(LocalDateTime cancelledAt) {
         this.status = AppealStatus.CANCELLED;
-        this.cancelledAt = cancelledAt == null ? LocalDateTime.now() : cancelledAt;
+        this.cancelledAt = cancelledAt;
     }
+
 }

--- a/src/main/java/com/project/domain/appeal/entity/PolicyAppeal.java
+++ b/src/main/java/com/project/domain/appeal/entity/PolicyAppeal.java
@@ -82,4 +82,31 @@ public class PolicyAppeal extends BaseEntity {
 
     @Column(name = "emergency_grant_month")
     private LocalDate emergencyGrantMonth;
+
+    public boolean isPending() {
+        return AppealStatus.PENDING.equals(this.status);
+    }
+
+    public boolean isEmergency() {
+        return AppealType.EMERGENCY.equals(this.type);
+    }
+
+    public void approve(Long resolverId, LocalDateTime resolvedAt) {
+        this.status = AppealStatus.APPROVED;
+        this.rejectReason = null;
+        this.resolvedById = resolverId;
+        this.resolvedAt = resolvedAt == null ? LocalDateTime.now() : resolvedAt;
+    }
+
+    public void reject(Long resolverId, String rejectReason, LocalDateTime resolvedAt) {
+        this.status = AppealStatus.REJECTED;
+        this.rejectReason = rejectReason;
+        this.resolvedById = resolverId;
+        this.resolvedAt = resolvedAt == null ? LocalDateTime.now() : resolvedAt;
+    }
+
+    public void cancel(LocalDateTime cancelledAt) {
+        this.status = AppealStatus.CANCELLED;
+        this.cancelledAt = cancelledAt == null ? LocalDateTime.now() : cancelledAt;
+    }
 }

--- a/src/main/java/com/project/domain/appeal/entity/PolicyAppeal.java
+++ b/src/main/java/com/project/domain/appeal/entity/PolicyAppeal.java
@@ -97,15 +97,16 @@ public class PolicyAppeal extends BaseEntity {
         this.resolvedById = resolverId;
         this.resolvedAt = resolvedAt;
     }
+
     public void reject(Long resolverId, String rejectReason, LocalDateTime resolvedAt) {
         this.status = AppealStatus.REJECTED;
         this.rejectReason = rejectReason;
         this.resolvedById = resolverId;
         this.resolvedAt = resolvedAt;
     }
+
     public void cancel(LocalDateTime cancelledAt) {
         this.status = AppealStatus.CANCELLED;
         this.cancelledAt = cancelledAt;
     }
-
 }

--- a/src/main/java/com/project/domain/appeal/model/AppealCancelResult.java
+++ b/src/main/java/com/project/domain/appeal/model/AppealCancelResult.java
@@ -1,0 +1,7 @@
+package com.project.domain.appeal.model;
+
+import java.time.LocalDateTime;
+
+import com.project.domain.appeal.enums.AppealStatus;
+
+public record AppealCancelResult(Long appealId, AppealStatus status, LocalDateTime cancelledAt) {}

--- a/src/main/java/com/project/domain/appeal/model/AppealCommentResult.java
+++ b/src/main/java/com/project/domain/appeal/model/AppealCommentResult.java
@@ -1,0 +1,6 @@
+package com.project.domain.appeal.model;
+
+import java.time.LocalDateTime;
+
+public record AppealCommentResult(
+        Long commentId, Long appealId, Long authorId, String comment, LocalDateTime createdAt) {}

--- a/src/main/java/com/project/domain/appeal/model/AppealCommentResult.java
+++ b/src/main/java/com/project/domain/appeal/model/AppealCommentResult.java
@@ -3,4 +3,9 @@ package com.project.domain.appeal.model;
 import java.time.LocalDateTime;
 
 public record AppealCommentResult(
-        Long commentId, Long appealId, Long authorId, String comment, LocalDateTime createdAt) {}
+        Long commentId,
+        Long appealId,
+        Long authorId,
+        String authorName,
+        String comment,
+        LocalDateTime createdAt) {}

--- a/src/main/java/com/project/domain/appeal/model/AppealRespondResult.java
+++ b/src/main/java/com/project/domain/appeal/model/AppealRespondResult.java
@@ -1,0 +1,12 @@
+package com.project.domain.appeal.model;
+
+import java.time.LocalDateTime;
+
+import com.project.domain.appeal.enums.AppealStatus;
+
+public record AppealRespondResult(
+        Long appealId,
+        AppealStatus status,
+        String rejectReason,
+        Long resolvedById,
+        LocalDateTime resolvedAt) {}

--- a/src/main/java/com/project/domain/appeal/service/AppealService.java
+++ b/src/main/java/com/project/domain/appeal/service/AppealService.java
@@ -1,7 +1,7 @@
 package com.project.domain.appeal.service;
 
-import com.project.domain.appeal.dto.request.AppealCreateRequest;
 import com.project.domain.appeal.dto.request.AppealCommentRequest;
+import com.project.domain.appeal.dto.request.AppealCreateRequest;
 import com.project.domain.appeal.dto.request.AppealRespondRequest;
 import com.project.domain.appeal.dto.request.EmergencyQuotaRequest;
 import com.project.domain.appeal.enums.AppealStatus;
@@ -26,10 +26,12 @@ public interface AppealService {
     AppealCreateResult createAppeal(AuthContext auth, AppealCreateRequest request);
 
     /** 이의제기 승인/거절 */
-    AppealRespondResult respondAppeal(AuthContext auth, Long appealId, AppealRespondRequest request);
+    AppealRespondResult respondAppeal(
+            AuthContext auth, Long appealId, AppealRespondRequest request);
 
     /** 이의제기 댓글 작성 */
-    AppealCommentResult createComment(AuthContext auth, Long appealId, AppealCommentRequest request);
+    AppealCommentResult createComment(
+            AuthContext auth, Long appealId, AppealCommentRequest request);
 
     /** 이의제기 취소 */
     AppealCancelResult cancelAppeal(AuthContext auth, Long appealId);

--- a/src/main/java/com/project/domain/appeal/service/AppealService.java
+++ b/src/main/java/com/project/domain/appeal/service/AppealService.java
@@ -1,11 +1,16 @@
 package com.project.domain.appeal.service;
 
 import com.project.domain.appeal.dto.request.AppealCreateRequest;
+import com.project.domain.appeal.dto.request.AppealCommentRequest;
+import com.project.domain.appeal.dto.request.AppealRespondRequest;
 import com.project.domain.appeal.dto.request.EmergencyQuotaRequest;
 import com.project.domain.appeal.enums.AppealStatus;
+import com.project.domain.appeal.model.AppealCancelResult;
+import com.project.domain.appeal.model.AppealCommentResult;
 import com.project.domain.appeal.model.AppealCreateResult;
 import com.project.domain.appeal.model.AppealDetailResult;
 import com.project.domain.appeal.model.AppealListResult;
+import com.project.domain.appeal.model.AppealRespondResult;
 import com.project.domain.appeal.model.EmergencyQuotaResult;
 import com.project.global.auth.model.AuthContext;
 
@@ -19,6 +24,15 @@ public interface AppealService {
 
     /** 이의제기 생성 */
     AppealCreateResult createAppeal(AuthContext auth, AppealCreateRequest request);
+
+    /** 이의제기 승인/거절 */
+    AppealRespondResult respondAppeal(AuthContext auth, Long appealId, AppealRespondRequest request);
+
+    /** 이의제기 댓글 작성 */
+    AppealCommentResult createComment(AuthContext auth, Long appealId, AppealCommentRequest request);
+
+    /** 이의제기 취소 */
+    AppealCancelResult cancelAppeal(AuthContext auth, Long appealId);
 
     /** 긴급 쿼터 요청 */
     EmergencyQuotaResult requestEmergencyQuota(AuthContext auth, EmergencyQuotaRequest request);

--- a/src/main/java/com/project/domain/appeal/service/AppealServiceImpl.java
+++ b/src/main/java/com/project/domain/appeal/service/AppealServiceImpl.java
@@ -235,7 +235,7 @@ public class AppealServiceImpl implements AppealService {
         } else {
             // 6. REJECTED면 거절 사유를 검증한 뒤 거절 처리한다.
             if (request.rejectReason() == null || request.rejectReason().isBlank()) {
-                throw new ApplicationException(AppealErrorCode.APPEAL_INVALID_DESIRED_RULES);
+                throw new ApplicationException(AppealErrorCode.APPEAL_REJECT_REASON_REQUIRED);
             }
             appeal.reject(auth.customerId(), request.rejectReason(), now);
         }
@@ -270,16 +270,13 @@ public class AppealServiceImpl implements AppealService {
                                 .build());
 
         // 4. 댓글 작성자 이름을 추가한다.
-        String authorName =
-                customerRepository
-                        .findById(auth.customerId())
-                        .map(Customer::getName)
-                        .orElse(UNKNOWN_NAME);
         return new AppealCommentResult(
                 comment.getId(),
                 comment.getAppealId(),
                 comment.getAuthorId(),
-                authorName,
+                auth.authorName() == null || auth.authorName().isBlank()
+                        ? UNKNOWN_NAME
+                        : auth.authorName(),
                 comment.getComment(),
                 comment.getCreatedAt());
     }
@@ -506,16 +503,16 @@ public class AppealServiceImpl implements AppealService {
 
     private AppealStatus parseRespondAction(String action) {
         if (action == null || action.isBlank()) {
-            throw new ApplicationException(AppealErrorCode.APPEAL_ALREADY_RESOLVED);
+            throw new ApplicationException(AppealErrorCode.APPEAL_INVALID_ACTION);
         }
         try {
             AppealStatus parsed = AppealStatus.valueOf(action.toUpperCase());
             if (AppealStatus.APPROVED.equals(parsed) || AppealStatus.REJECTED.equals(parsed)) {
                 return parsed;
             }
-            throw new ApplicationException(AppealErrorCode.APPEAL_ALREADY_RESOLVED);
+            throw new ApplicationException(AppealErrorCode.APPEAL_INVALID_ACTION);
         } catch (IllegalArgumentException e) {
-            throw new ApplicationException(AppealErrorCode.APPEAL_ALREADY_RESOLVED);
+            throw new ApplicationException(AppealErrorCode.APPEAL_INVALID_ACTION);
         }
     }
 

--- a/src/main/java/com/project/domain/appeal/service/AppealServiceImpl.java
+++ b/src/main/java/com/project/domain/appeal/service/AppealServiceImpl.java
@@ -2,11 +2,15 @@ package com.project.domain.appeal.service;
 
 import java.time.Clock;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
@@ -14,14 +18,19 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.project.domain.appeal.dto.request.AppealCreateRequest;
+import com.project.domain.appeal.dto.request.AppealCommentRequest;
+import com.project.domain.appeal.dto.request.AppealRespondRequest;
 import com.project.domain.appeal.dto.request.EmergencyQuotaRequest;
 import com.project.domain.appeal.entity.PolicyAppeal;
 import com.project.domain.appeal.entity.PolicyAppealComment;
 import com.project.domain.appeal.enums.AppealStatus;
 import com.project.domain.appeal.enums.AppealType;
+import com.project.domain.appeal.model.AppealCancelResult;
+import com.project.domain.appeal.model.AppealCommentResult;
 import com.project.domain.appeal.model.AppealCreateResult;
 import com.project.domain.appeal.model.AppealDetailResult;
 import com.project.domain.appeal.model.AppealListResult;
+import com.project.domain.appeal.model.AppealRespondResult;
 import com.project.domain.appeal.model.EmergencyQuotaResult;
 import com.project.domain.appeal.repository.PolicyAppealCommentRepository;
 import com.project.domain.appeal.repository.PolicyAppealRepository;
@@ -65,6 +74,7 @@ public class AppealServiceImpl implements AppealService {
     private final PolicyAssignmentRepository policyAssignmentRepository;
     private final PolicyRepository policyRepository;
     private final CustomerQuotaRepository customerQuotaRepository;
+    private final ObjectMapper objectMapper;
 
     /** 이의제기 목록 조회 */
     @Override
@@ -196,6 +206,105 @@ public class AppealServiceImpl implements AppealService {
                 appeal.getStatus(),
                 appeal.getDesiredRules(),
                 appeal.getCreatedAt());
+    }
+
+    /** 이의제기 승인/거절 */
+    @Override
+    @Transactional
+    public AppealRespondResult respondAppeal(
+            AuthContext auth, Long appealId, AppealRespondRequest request) {
+        // 1. OWNER만 요청을 승인/거절할 수 있다.
+        validateOwnerOnly(auth);
+
+        // 2. 이의제기 존재 여부와 같은 가족 접근 가능 여부를 검증한다.
+        PolicyAppeal appeal = findAppealOrThrow(appealId);
+        validateFamilyAccess(auth.familyId(), appeal);
+
+        // 3. 아직 처리 가능한 PENDING 상태인지 확인한다.
+        if (!appeal.isPending()) {
+            throw new ApplicationException(AppealErrorCode.APPEAL_ALREADY_RESOLVED);
+        }
+
+        // 4. action 값을 승인/거절 중 하나로 파싱한다.
+        AppealStatus action = parseRespondAction(request.action());
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        // 5. APPROVED면 승인 처리하고 desiredRules가 있으면 정책 규칙에도 반영한다.
+        if (AppealStatus.APPROVED.equals(action)) {
+            appeal.approve(auth.customerId(), now);
+            applyDesiredRulesIfPresent(appeal, auth.customerId());
+        } else {
+            // 6. REJECTED면 거절 사유를 검증한 뒤 거절 처리한다.
+            if (request.rejectReason() == null || request.rejectReason().isBlank()) {
+                throw new ApplicationException(AppealErrorCode.APPEAL_INVALID_DESIRED_RULES);
+            }
+            appeal.reject(auth.customerId(), request.rejectReason(), now);
+        }
+
+        return new AppealRespondResult(
+                appeal.getId(),
+                appeal.getStatus(),
+                appeal.getRejectReason(),
+                appeal.getResolvedById(),
+                appeal.getResolvedAt());
+    }
+
+    /** 이의제기 댓글 작성 */
+    @Override
+    @Transactional
+    public AppealCommentResult createComment(
+            AuthContext auth, Long appealId, AppealCommentRequest request) {
+        // 1. 이의제기 존재 여부와 같은 가족 접근 가능 여부를 검증한다.
+        PolicyAppeal appeal = findAppealOrThrow(appealId);
+        validateFamilyAccess(auth.familyId(), appeal);
+
+        // 2. OWNER와 MEMBER 모두 댓글 작성 가능하되, 가족 소속 구성원만 허용한다.
+        validateFamilyMemberExists(auth.customerId(), auth.familyId());
+
+        // 3. 댓글을 저장하고 응답 모델로 반환한다.
+        PolicyAppealComment comment =
+                policyAppealCommentRepository.save(
+                        PolicyAppealComment.builder()
+                                .appealId(appealId)
+                                .authorId(auth.customerId())
+                                .comment(request.comment())
+                                .build());
+        return new AppealCommentResult(
+                comment.getId(),
+                comment.getAppealId(),
+                comment.getAuthorId(),
+                comment.getComment(),
+                comment.getCreatedAt());
+    }
+
+    /** 이의제기 취소 */
+    @Override
+    @Transactional
+    public AppealCancelResult cancelAppeal(AuthContext auth, Long appealId) {
+        // 1. MEMBER만 본인 이의제기를 취소할 수 있다.
+        validateMemberOnly(auth);
+
+        // 2. 이의제기 존재 여부를 확인한다.
+        PolicyAppeal appeal = findAppealOrThrow(appealId);
+
+        // 3. 본인 생성 건인지 확인한다.
+        if (!appeal.getRequesterId().equals(auth.customerId())) {
+            throw new ApplicationException(AppealErrorCode.APPEAL_CANCEL_FORBIDDEN);
+        }
+
+        // 4. EMERGENCY 타입은 취소할 수 없다.
+        if (appeal.isEmergency()) {
+            throw new ApplicationException(AppealErrorCode.APPEAL_EMERGENCY_CANCEL_NOT_ALLOWED);
+        }
+
+        // 5. 아직 처리 전인 PENDING 상태만 취소할 수 있다.
+        if (!appeal.isPending()) {
+            throw new ApplicationException(AppealErrorCode.APPEAL_NOT_CANCELLABLE);
+        }
+
+        // 6. 취소 상태와 시각을 기록한다.
+        appeal.cancel(LocalDateTime.now(clock));
+        return new AppealCancelResult(appeal.getId(), appeal.getStatus(), appeal.getCancelledAt());
     }
 
     /** 긴급 쿼터 요청 */
@@ -347,6 +456,59 @@ public class AppealServiceImpl implements AppealService {
                         .orElseThrow(
                                 () -> new ApplicationException(PolicyErrorCode.POLICY_NOT_FOUND));
         return policy.getPolicyType();
+    }
+
+    private void applyDesiredRulesIfPresent(PolicyAppeal appeal, Long actorId) {
+        if (appeal.getDesiredRules() == null || appeal.getDesiredRules().isEmpty()) {
+            return;
+        }
+        if (appeal.getPolicyAssignmentId() == null) {
+            return;
+        }
+        PolicyAssignment assignment =
+                policyAssignmentRepository
+                        .findByIdAndDeletedAtIsNull(appeal.getPolicyAssignmentId())
+                        .orElseThrow(
+                                () ->
+                                        new ApplicationException(
+                                                PolicyErrorCode.POLICY_ASSIGNMENT_NOT_FOUND));
+        try {
+            assignment.update(objectMapper.writeValueAsString(appeal.getDesiredRules()), null, actorId);
+        } catch (JsonProcessingException e) {
+            throw new ApplicationException(AppealErrorCode.APPEAL_INVALID_DESIRED_RULES);
+        }
+    }
+
+    private void validateOwnerOnly(AuthContext auth) {
+        if (!auth.isOwner()) {
+            throw new ApplicationException(AppealErrorCode.APPEAL_FORBIDDEN);
+        }
+    }
+
+    private void validateFamilyMemberExists(Long customerId, Long familyId) {
+        FamilyMember member =
+                familyMemberRepository
+                        .findByCustomerId(customerId)
+                        .orElseThrow(
+                                () -> new ApplicationException(AppealErrorCode.APPEAL_FORBIDDEN));
+        if (!member.getFamilyId().equals(familyId)) {
+            throw new ApplicationException(AppealErrorCode.APPEAL_FORBIDDEN);
+        }
+    }
+
+    private AppealStatus parseRespondAction(String action) {
+        if (action == null || action.isBlank()) {
+            throw new ApplicationException(AppealErrorCode.APPEAL_ALREADY_RESOLVED);
+        }
+        try {
+            AppealStatus parsed = AppealStatus.valueOf(action.toUpperCase());
+            if (AppealStatus.APPROVED.equals(parsed) || AppealStatus.REJECTED.equals(parsed)) {
+                return parsed;
+            }
+            throw new ApplicationException(AppealErrorCode.APPEAL_ALREADY_RESOLVED);
+        } catch (IllegalArgumentException e) {
+            throw new ApplicationException(AppealErrorCode.APPEAL_ALREADY_RESOLVED);
+        }
     }
 
     /** 요청자 ID 목록 추출 */

--- a/src/main/java/com/project/domain/appeal/service/AppealServiceImpl.java
+++ b/src/main/java/com/project/domain/appeal/service/AppealServiceImpl.java
@@ -269,10 +269,16 @@ public class AppealServiceImpl implements AppealService {
                                 .authorId(auth.customerId())
                                 .comment(request.comment())
                                 .build());
+        String authorName =
+                customerRepository
+                        .findById(auth.customerId())
+                        .map(Customer::getName)
+                        .orElse(UNKNOWN_NAME);
         return new AppealCommentResult(
                 comment.getId(),
                 comment.getAppealId(),
                 comment.getAuthorId(),
+                authorName,
                 comment.getComment(),
                 comment.getCreatedAt());
     }

--- a/src/main/java/com/project/domain/appeal/service/AppealServiceImpl.java
+++ b/src/main/java/com/project/domain/appeal/service/AppealServiceImpl.java
@@ -9,16 +9,15 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.project.domain.appeal.dto.request.AppealCreateRequest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.domain.appeal.dto.request.AppealCommentRequest;
+import com.project.domain.appeal.dto.request.AppealCreateRequest;
 import com.project.domain.appeal.dto.request.AppealRespondRequest;
 import com.project.domain.appeal.dto.request.EmergencyQuotaRequest;
 import com.project.domain.appeal.entity.PolicyAppeal;
@@ -269,6 +268,8 @@ public class AppealServiceImpl implements AppealService {
                                 .authorId(auth.customerId())
                                 .comment(request.comment())
                                 .build());
+
+        // 4. 댓글 작성자 이름을 추가한다.
         String authorName =
                 customerRepository
                         .findById(auth.customerId())
@@ -479,7 +480,8 @@ public class AppealServiceImpl implements AppealService {
                                         new ApplicationException(
                                                 PolicyErrorCode.POLICY_ASSIGNMENT_NOT_FOUND));
         try {
-            assignment.update(objectMapper.writeValueAsString(appeal.getDesiredRules()), null, actorId);
+            assignment.update(
+                    objectMapper.writeValueAsString(appeal.getDesiredRules()), null, actorId);
         } catch (JsonProcessingException e) {
             throw new ApplicationException(AppealErrorCode.APPEAL_INVALID_DESIRED_RULES);
         }

--- a/src/main/java/com/project/domain/mission/enums/MissionLogActionType.java
+++ b/src/main/java/com/project/domain/mission/enums/MissionLogActionType.java
@@ -5,8 +5,8 @@ package com.project.domain.mission.enums;
  * 부모가 요청을 승인해 미션이 완료됨
  */
 public enum MissionLogActionType {
-    CREATED,
-    REQUESTED,
-    CANCELLED,
-    COMPLETED
+    MISSION_CREATED,
+    MISSION_REQUESTED,
+    MISSION_COMPLETED,
+    MISSION_CANCELLED
 }

--- a/src/main/java/com/project/domain/mission/service/MissionServiceImpl.java
+++ b/src/main/java/com/project/domain/mission/service/MissionServiceImpl.java
@@ -212,7 +212,7 @@ public class MissionServiceImpl implements MissionService {
         appendLog(
                 mission.getId(),
                 auth.customerId(),
-                MissionLogActionType.CREATED,
+                MissionLogActionType.MISSION_CREATED,
                 "Mission created");
         return new CreateMissionResult(mission.getId(), mission.getCreatedAt());
     }
@@ -231,7 +231,7 @@ public class MissionServiceImpl implements MissionService {
         appendLog(
                 mission.getId(),
                 auth.customerId(),
-                MissionLogActionType.CANCELLED,
+                MissionLogActionType.MISSION_CANCELLED,
                 "Mission cancelled");
     }
 
@@ -269,7 +269,7 @@ public class MissionServiceImpl implements MissionService {
         appendLog(
                 mission.getId(),
                 auth.customerId(),
-                MissionLogActionType.REQUESTED,
+                MissionLogActionType.MISSION_REQUESTED,
                 "Mission requested");
 
         // 3. 응답에는 MissionItem이 참조하는 Reward 스냅샷을 그대로 사용한다.

--- a/src/main/java/com/project/domain/reward/dto/response/RewardResponse.java
+++ b/src/main/java/com/project/domain/reward/dto/response/RewardResponse.java
@@ -4,7 +4,11 @@ import com.project.domain.mission.model.MissionListResult;
 
 /** 보상 정보 응답 DTO */
 public record RewardResponse(
-        Long rewardId, String name, String category, String thumbnailUrl, Long templateId) {
+        Long rewardId,
+        String name,
+        String category,
+        String thumbnailUrl,
+        Long templateId) {
     public static RewardResponse from(MissionListResult.Reward reward) {
         return new RewardResponse(
                 reward.rewardId(),

--- a/src/main/java/com/project/domain/reward/dto/response/RewardResponse.java
+++ b/src/main/java/com/project/domain/reward/dto/response/RewardResponse.java
@@ -4,11 +4,7 @@ import com.project.domain.mission.model.MissionListResult;
 
 /** 보상 정보 응답 DTO */
 public record RewardResponse(
-        Long rewardId,
-        String name,
-        String category,
-        String thumbnailUrl,
-        Long templateId) {
+        Long rewardId, String name, String category, String thumbnailUrl, Long templateId) {
     public static RewardResponse from(MissionListResult.Reward reward) {
         return new RewardResponse(
                 reward.rewardId(),

--- a/src/main/java/com/project/domain/reward/service/RewardServiceImpl.java
+++ b/src/main/java/com/project/domain/reward/service/RewardServiceImpl.java
@@ -92,7 +92,7 @@ public class RewardServiceImpl implements RewardService {
             appendLog(
                     mission.getId(),
                     auth.customerId(),
-                    MissionLogActionType.COMPLETED,
+                    MissionLogActionType.MISSION_COMPLETED,
                     "Mission completed");
 
             Customer requester =

--- a/src/main/java/com/project/global/auth/model/AuthContext.java
+++ b/src/main/java/com/project/global/auth/model/AuthContext.java
@@ -3,7 +3,11 @@ package com.project.global.auth.model;
 import com.project.domain.customer.enums.RoleType;
 
 /** 인증된 사용자의 ID, 가족 ID, 역할을 담는 컨텍스트 모델입니다. 여러 도메인 서비스에서 공통으로 사용됩니다. */
-public record AuthContext(Long customerId, Long familyId, RoleType role) {
+public record AuthContext(Long customerId, Long familyId, RoleType role, String authorName) {
+    public AuthContext(Long customerId, Long familyId, RoleType role) {
+        this(customerId, familyId, role, null);
+    }
+
     public boolean isOwner() {
         return RoleType.OWNER.equals(role);
     }

--- a/src/main/java/com/project/global/auth/service/AuthContextService.java
+++ b/src/main/java/com/project/global/auth/service/AuthContextService.java
@@ -31,7 +31,9 @@ public class AuthContextService {
                 customerRepository
                         .findById(customerId)
                         .orElseThrow(
-                                () -> new ApplicationException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
+                                () ->
+                                        new ApplicationException(
+                                                CustomerErrorCode.CUSTOMER_NOT_FOUND));
         return new AuthContext(
                 customerId, member.getFamilyId(), member.getRole(), customer.getName());
     }

--- a/src/main/java/com/project/global/auth/service/AuthContextService.java
+++ b/src/main/java/com/project/global/auth/service/AuthContextService.java
@@ -2,10 +2,13 @@ package com.project.global.auth.service;
 
 import org.springframework.stereotype.Component;
 
+import com.project.domain.customer.entity.Customer;
+import com.project.domain.customer.repository.CustomerRepository;
 import com.project.domain.family.entity.FamilyMember;
 import com.project.domain.family.repository.FamilyMemberRepository;
 import com.project.global.auth.model.AuthContext;
 import com.project.global.exception.ApplicationException;
+import com.project.global.exception.code.CustomerErrorCode;
 import com.project.global.exception.code.FamilyErrorCode;
 
 import lombok.RequiredArgsConstructor;
@@ -16,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 public class AuthContextService {
 
     private final FamilyMemberRepository familyMemberRepository;
+    private final CustomerRepository customerRepository;
 
     public AuthContext resolve(Long customerId) {
         FamilyMember member =
@@ -23,6 +27,12 @@ public class AuthContextService {
                         .findByCustomerId(customerId)
                         .orElseThrow(
                                 () -> new ApplicationException(FamilyErrorCode.FAMILY_NOT_FOUND));
-        return new AuthContext(customerId, member.getFamilyId(), member.getRole());
+        Customer customer =
+                customerRepository
+                        .findById(customerId)
+                        .orElseThrow(
+                                () -> new ApplicationException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
+        return new AuthContext(
+                customerId, member.getFamilyId(), member.getRole(), customer.getName());
     }
 }

--- a/src/main/java/com/project/global/exception/code/AppealErrorCode.java
+++ b/src/main/java/com/project/global/exception/code/AppealErrorCode.java
@@ -22,7 +22,9 @@ public enum AppealErrorCode implements BaseErrorCode {
     APPEAL_NOT_CANCELLABLE(HttpStatus.CONFLICT, "APPEAL_009", "취소할 수 없는 상태입니다."),
     APPEAL_EMERGENCY_CANCEL_NOT_ALLOWED(
             HttpStatus.BAD_REQUEST, "APPEAL_010", "EMERGENCY 타입은 취소할 수 없습니다."),
-    APPEAL_ALREADY_PENDING(HttpStatus.CONFLICT, "APPEAL_011", "같은 정책에 대해 진행 중인 이의제기가 이미 존재합니다.");
+    APPEAL_ALREADY_PENDING(HttpStatus.CONFLICT, "APPEAL_011", "같은 정책에 대해 진행 중인 이의제기가 이미 존재합니다."),
+    APPEAL_REJECT_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "APPEAL_012", "이의제기 거절 시 사유는 필수입니다."),
+    APPEAL_INVALID_ACTION(HttpStatus.BAD_REQUEST, "APPEAL_013", "유효하지 않은 처리 액션입니다. 'APPROVED' 또는 'REJECTED'만 사용할 수 있습니다.");
 
     private final HttpStatus httpStatus;
     private final String customCode;

--- a/src/main/java/com/project/global/exception/code/AppealErrorCode.java
+++ b/src/main/java/com/project/global/exception/code/AppealErrorCode.java
@@ -24,7 +24,10 @@ public enum AppealErrorCode implements BaseErrorCode {
             HttpStatus.BAD_REQUEST, "APPEAL_010", "EMERGENCY 타입은 취소할 수 없습니다."),
     APPEAL_ALREADY_PENDING(HttpStatus.CONFLICT, "APPEAL_011", "같은 정책에 대해 진행 중인 이의제기가 이미 존재합니다."),
     APPEAL_REJECT_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "APPEAL_012", "이의제기 거절 시 사유는 필수입니다."),
-    APPEAL_INVALID_ACTION(HttpStatus.BAD_REQUEST, "APPEAL_013", "유효하지 않은 처리 액션입니다. 'APPROVED' 또는 'REJECTED'만 사용할 수 있습니다.");
+    APPEAL_INVALID_ACTION(
+            HttpStatus.BAD_REQUEST,
+            "APPEAL_013",
+            "유효하지 않은 처리 액션입니다. 'APPROVED' 또는 'REJECTED'만 사용할 수 있습니다.");
 
     private final HttpStatus httpStatus;
     private final String customCode;

--- a/src/test/java/com/project/domain/appeal/service/AppealServiceImplTest.java
+++ b/src/test/java/com/project/domain/appeal/service/AppealServiceImplTest.java
@@ -15,9 +15,6 @@ import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,8 +24,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 
-import com.project.domain.appeal.dto.request.AppealCreateRequest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.domain.appeal.dto.request.AppealCommentRequest;
+import com.project.domain.appeal.dto.request.AppealCreateRequest;
 import com.project.domain.appeal.dto.request.AppealRespondRequest;
 import com.project.domain.appeal.dto.request.EmergencyQuotaRequest;
 import com.project.domain.appeal.entity.PolicyAppeal;
@@ -370,7 +369,8 @@ class AppealServiceImplTest {
                                         .customerId(1L)
                                         .role(RoleType.OWNER)
                                         .build()));
-        given(customerRepository.findById(1L)).willReturn(java.util.Optional.of(customer(1L, "owner")));
+        given(customerRepository.findById(1L))
+                .willReturn(java.util.Optional.of(customer(1L, "owner")));
         given(policyAppealCommentRepository.save(any(PolicyAppealComment.class))).willReturn(saved);
 
         var result = appealService.createComment(auth, 30L, new AppealCommentRequest("확인 후 처리할게요"));

--- a/src/test/java/com/project/domain/appeal/service/AppealServiceImplTest.java
+++ b/src/test/java/com/project/domain/appeal/service/AppealServiceImplTest.java
@@ -370,12 +370,14 @@ class AppealServiceImplTest {
                                         .customerId(1L)
                                         .role(RoleType.OWNER)
                                         .build()));
+        given(customerRepository.findById(1L)).willReturn(java.util.Optional.of(customer(1L, "owner")));
         given(policyAppealCommentRepository.save(any(PolicyAppealComment.class))).willReturn(saved);
 
         var result = appealService.createComment(auth, 30L, new AppealCommentRequest("확인 후 처리할게요"));
 
         assertThat(result.commentId()).isEqualTo(50L);
         assertThat(result.authorId()).isEqualTo(1L);
+        assertThat(result.authorName()).isEqualTo("owner");
         assertThat(result.comment()).isEqualTo("확인 후 처리할게요");
     }
 

--- a/src/test/java/com/project/domain/appeal/service/AppealServiceImplTest.java
+++ b/src/test/java/com/project/domain/appeal/service/AppealServiceImplTest.java
@@ -93,7 +93,7 @@ class AppealServiceImplTest {
     @Test
     @DisplayName("OWNER는 가족 전체 이의제기를 조회한다")
     void getAppeals_whenOwner_thenReturnsFamilyAppeals() {
-        AuthContext auth = new AuthContext(1L, 10L, RoleType.OWNER);
+        AuthContext auth = new AuthContext(1L, 10L, RoleType.OWNER, "owner");
         PolicyAppeal first = appeal(30L, 2L, 100L, AppealStatus.PENDING);
         PolicyAppeal second = appeal(29L, 3L, 101L, AppealStatus.APPROVED);
         given(policyAppealRepository.findAllByFamilyId(10L, null, null, PageRequest.of(0, 21)))
@@ -135,7 +135,7 @@ class AppealServiceImplTest {
     @Test
     @DisplayName("목록 조회는 커서 기반 nextCursor와 hasNext를 계산한다")
     void getAppeals_whenMoreThanSize_thenReturnsNextCursor() {
-        AuthContext auth = new AuthContext(1L, 10L, RoleType.OWNER);
+        AuthContext auth = new AuthContext(1L, 10L, RoleType.OWNER, "owner");
         given(policyAppealRepository.findAllByFamilyId(10L, null, 50L, PageRequest.of(0, 3)))
                 .willReturn(
                         List.of(
@@ -155,7 +155,7 @@ class AppealServiceImplTest {
     @Test
     @DisplayName("상세 조회는 같은 가족의 댓글 커서 페이지와 정책 타입을 반환한다")
     void getAppealDetail_whenSameFamily_thenReturnsDetail() {
-        AuthContext auth = new AuthContext(1L, 10L, RoleType.OWNER);
+        AuthContext auth = new AuthContext(1L, 10L, RoleType.OWNER, "owner");
         PolicyAppeal appeal = appeal(30L, 2L, 100L, AppealStatus.PENDING);
         PolicyAppealComment firstComment = comment(20L, 2L, "첫 댓글");
         PolicyAppealComment secondComment = comment(19L, 1L, "둘째 댓글");
@@ -336,7 +336,7 @@ class AppealServiceImplTest {
     @Test
     @DisplayName("가족 구성원은 이의제기에 댓글을 작성할 수 있다")
     void createComment_whenFamilyMember_thenCreatesComment() {
-        AuthContext auth = new AuthContext(1L, 10L, RoleType.OWNER);
+        AuthContext auth = new AuthContext(1L, 10L, RoleType.OWNER, "owner");
         PolicyAppeal appeal = appeal(30L, 2L, 100L, AppealStatus.PENDING);
         PolicyAppealComment saved =
                 PolicyAppealComment.builder()
@@ -369,8 +369,6 @@ class AppealServiceImplTest {
                                         .customerId(1L)
                                         .role(RoleType.OWNER)
                                         .build()));
-        given(customerRepository.findById(1L))
-                .willReturn(java.util.Optional.of(customer(1L, "owner")));
         given(policyAppealCommentRepository.save(any(PolicyAppealComment.class))).willReturn(saved);
 
         var result = appealService.createComment(auth, 30L, new AppealCommentRequest("확인 후 처리할게요"));

--- a/src/test/java/com/project/domain/appeal/service/AppealServiceImplTest.java
+++ b/src/test/java/com/project/domain/appeal/service/AppealServiceImplTest.java
@@ -15,6 +15,9 @@ import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,6 +28,8 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 
 import com.project.domain.appeal.dto.request.AppealCreateRequest;
+import com.project.domain.appeal.dto.request.AppealCommentRequest;
+import com.project.domain.appeal.dto.request.AppealRespondRequest;
 import com.project.domain.appeal.dto.request.EmergencyQuotaRequest;
 import com.project.domain.appeal.entity.PolicyAppeal;
 import com.project.domain.appeal.entity.PolicyAppealComment;
@@ -33,6 +38,7 @@ import com.project.domain.appeal.enums.AppealType;
 import com.project.domain.appeal.model.AppealCreateResult;
 import com.project.domain.appeal.model.AppealDetailResult;
 import com.project.domain.appeal.model.AppealListResult;
+import com.project.domain.appeal.model.AppealRespondResult;
 import com.project.domain.appeal.model.EmergencyQuotaResult;
 import com.project.domain.appeal.repository.PolicyAppealCommentRepository;
 import com.project.domain.appeal.repository.PolicyAppealRepository;
@@ -66,6 +72,7 @@ class AppealServiceImplTest {
     @Mock private PolicyAssignmentRepository policyAssignmentRepository;
     @Mock private PolicyRepository policyRepository;
     @Mock private CustomerQuotaRepository customerQuotaRepository;
+    @Mock private ObjectMapper objectMapper;
 
     private AppealServiceImpl appealService;
 
@@ -80,7 +87,8 @@ class AppealServiceImplTest {
                         familyMemberRepository,
                         policyAssignmentRepository,
                         policyRepository,
-                        customerQuotaRepository);
+                        customerQuotaRepository,
+                        objectMapper);
     }
 
     @Test
@@ -252,6 +260,123 @@ class AppealServiceImplTest {
                 .isInstanceOf(ApplicationException.class)
                 .extracting(ex -> ((ApplicationException) ex).getCode())
                 .isEqualTo(AppealErrorCode.APPEAL_ALREADY_PENDING);
+    }
+
+    @Test
+    @DisplayName("OWNER는 PENDING 이의제기를 승인하고 desiredRules를 정책에 반영한다")
+    void respondAppeal_whenApproved_thenUpdatesStatusAndAssignmentRules()
+            throws JsonProcessingException {
+        AuthContext auth = new AuthContext(1L, 10L, RoleType.OWNER);
+        PolicyAppeal appeal = appeal(30L, 2L, 100L, AppealStatus.PENDING);
+        PolicyAssignment assignment = policyAssignment(100L, 50L, 10L, 2L);
+
+        given(policyAppealRepository.findByIdAndDeletedAtIsNull(30L))
+                .willReturn(java.util.Optional.of(appeal));
+        given(familyMemberRepository.findByCustomerId(2L))
+                .willReturn(
+                        java.util.Optional.of(
+                                FamilyMember.builder()
+                                        .familyId(10L)
+                                        .customerId(2L)
+                                        .role(RoleType.MEMBER)
+                                        .build()));
+        given(policyAssignmentRepository.findByIdAndDeletedAtIsNull(100L))
+                .willReturn(java.util.Optional.of(assignment));
+        given(objectMapper.writeValueAsString(appeal.getDesiredRules()))
+                .willReturn("{\"limitBytes\":1024}");
+
+        AppealRespondResult result =
+                appealService.respondAppeal(auth, 30L, new AppealRespondRequest("APPROVED", null));
+
+        assertThat(result.status()).isEqualTo(AppealStatus.APPROVED);
+        assertThat(result.resolvedById()).isEqualTo(1L);
+        assertThat(assignment.getRules()).isEqualTo("{\"limitBytes\":1024}");
+    }
+
+    @Test
+    @DisplayName("OWNER는 PENDING 이의제기를 거절하고 rejectReason을 기록한다")
+    void respondAppeal_whenRejected_thenStoresRejectReason() {
+        AuthContext auth = new AuthContext(1L, 10L, RoleType.OWNER);
+        PolicyAppeal appeal = appeal(30L, 2L, 100L, AppealStatus.PENDING);
+
+        given(policyAppealRepository.findByIdAndDeletedAtIsNull(30L))
+                .willReturn(java.util.Optional.of(appeal));
+        given(familyMemberRepository.findByCustomerId(2L))
+                .willReturn(
+                        java.util.Optional.of(
+                                FamilyMember.builder()
+                                        .familyId(10L)
+                                        .customerId(2L)
+                                        .role(RoleType.MEMBER)
+                                        .build()));
+
+        AppealRespondResult result =
+                appealService.respondAppeal(
+                        auth, 30L, new AppealRespondRequest("REJECTED", "rules are not clear"));
+
+        assertThat(result.status()).isEqualTo(AppealStatus.REJECTED);
+        assertThat(result.rejectReason()).isEqualTo("rules are not clear");
+        assertThat(result.resolvedById()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("MEMBER는 본인 NORMAL PENDING 이의제기만 취소할 수 있다")
+    void cancelAppeal_whenOwnPendingNormal_thenCancels() {
+        AuthContext auth = new AuthContext(2L, 10L, RoleType.MEMBER);
+        PolicyAppeal appeal = appeal(30L, 2L, 100L, AppealStatus.PENDING);
+        given(policyAppealRepository.findByIdAndDeletedAtIsNull(30L))
+                .willReturn(java.util.Optional.of(appeal));
+
+        var result = appealService.cancelAppeal(auth, 30L);
+
+        assertThat(result.appealId()).isEqualTo(30L);
+        assertThat(result.status()).isEqualTo(AppealStatus.CANCELLED);
+        assertThat(result.cancelledAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("가족 구성원은 이의제기에 댓글을 작성할 수 있다")
+    void createComment_whenFamilyMember_thenCreatesComment() {
+        AuthContext auth = new AuthContext(1L, 10L, RoleType.OWNER);
+        PolicyAppeal appeal = appeal(30L, 2L, 100L, AppealStatus.PENDING);
+        PolicyAppealComment saved =
+                PolicyAppealComment.builder()
+                        .id(50L)
+                        .appealId(30L)
+                        .authorId(1L)
+                        .comment("확인 후 처리할게요")
+                        .build();
+        setField(
+                saved,
+                saved.getClass().getSuperclass(),
+                "createdAt",
+                LocalDateTime.of(2026, 3, 10, 12, 0));
+
+        given(policyAppealRepository.findByIdAndDeletedAtIsNull(30L))
+                .willReturn(java.util.Optional.of(appeal));
+        given(familyMemberRepository.findByCustomerId(2L))
+                .willReturn(
+                        java.util.Optional.of(
+                                FamilyMember.builder()
+                                        .familyId(10L)
+                                        .customerId(2L)
+                                        .role(RoleType.MEMBER)
+                                        .build()));
+        given(familyMemberRepository.findByCustomerId(1L))
+                .willReturn(
+                        java.util.Optional.of(
+                                FamilyMember.builder()
+                                        .familyId(10L)
+                                        .customerId(1L)
+                                        .role(RoleType.OWNER)
+                                        .build()));
+        given(policyAppealCommentRepository.save(any(PolicyAppealComment.class))).willReturn(saved);
+
+        var result = appealService.createComment(auth, 30L, new AppealCommentRequest("확인 후 처리할게요"));
+
+        assertThat(result.commentId()).isEqualTo(50L);
+        assertThat(result.authorId()).isEqualTo(1L);
+        assertThat(result.comment()).isEqualTo("확인 후 처리할게요");
     }
 
     @Test

--- a/src/test/java/com/project/domain/mission/controller/MissionControllerIntegrationTest.java
+++ b/src/test/java/com/project/domain/mission/controller/MissionControllerIntegrationTest.java
@@ -192,9 +192,7 @@ class MissionControllerIntegrationTest {
                         .readTree(requestResult.getResponse().getContentAsString())
                         .path("data");
         assertRewardNode(
-                requestData.path("missionItem").path("reward"),
-                rewardTemplate.getId(),
-                "data reward");
+                requestData.path("missionItem").path("reward"), rewardTemplate.getId(), "data reward");
 
         MvcResult missionListResult =
                 mockMvc.perform(
@@ -228,14 +226,23 @@ class MissionControllerIntegrationTest {
                                         .param("size", "20"))
                         .andExpect(status().isOk())
                         .andReturn();
-        JsonNode logNode =
+        JsonNode logList =
                 objectMapper
                         .readTree(logsResult.getResponse().getContentAsString())
                         .path("data")
-                        .path("missions")
-                        .get(0);
+                        .path("missions");
+        JsonNode logNode = null;
+        for (JsonNode node : logList) {
+            if (node.path("missionItem").path("missionItemId").asLong() == createdMissionId) {
+                logNode = node;
+                break;
+            }
+        }
+        assertThat(logNode).isNotNull();
         assertRewardNode(
-                logNode.path("missionItem").path("reward"), rewardTemplate.getId(), "data reward");
+                Objects.requireNonNull(logNode).path("missionItem").path("reward"),
+                rewardTemplate.getId(),
+                "data reward");
     }
 
     @Test
@@ -299,21 +306,21 @@ class MissionControllerIntegrationTest {
                 MissionLog.builder()
                         .missionItemId(mission.getId())
                         .actorId(owner.getId())
-                        .actionType(MissionLogActionType.CREATED)
+                        .actionType(MissionLogActionType.MISSION_CREATED)
                         .message("created")
                         .build());
         missionLogRepository.save(
                 MissionLog.builder()
                         .missionItemId(mission.getId())
                         .actorId(member.getId())
-                        .actionType(MissionLogActionType.REQUESTED)
+                        .actionType(MissionLogActionType.MISSION_REQUESTED)
                         .message("requested")
                         .build());
         missionLogRepository.save(
                 MissionLog.builder()
                         .missionItemId(mission.getId())
                         .actorId(owner.getId())
-                        .actionType(MissionLogActionType.COMPLETED)
+                        .actionType(MissionLogActionType.MISSION_COMPLETED)
                         .message("completed")
                         .build());
 
@@ -370,5 +377,6 @@ class MissionControllerIntegrationTest {
         assertThat(rewardNode.has("rewardId")).isTrue();
         assertThat(rewardNode.path("templateId").asLong()).isEqualTo(templateId);
         assertThat(rewardNode.path("name").asText()).isEqualTo(expectedName);
+        assertThat(rewardNode.has("rewardValue")).isFalse();
     }
 }

--- a/src/test/java/com/project/domain/mission/controller/MissionControllerIntegrationTest.java
+++ b/src/test/java/com/project/domain/mission/controller/MissionControllerIntegrationTest.java
@@ -192,7 +192,9 @@ class MissionControllerIntegrationTest {
                         .readTree(requestResult.getResponse().getContentAsString())
                         .path("data");
         assertRewardNode(
-                requestData.path("missionItem").path("reward"), rewardTemplate.getId(), "data reward");
+                requestData.path("missionItem").path("reward"),
+                rewardTemplate.getId(),
+                "data reward");
 
         MvcResult missionListResult =
                 mockMvc.perform(

--- a/src/test/java/com/project/domain/mission/service/MissionServiceImplTest.java
+++ b/src/test/java/com/project/domain/mission/service/MissionServiceImplTest.java
@@ -147,7 +147,7 @@ class MissionServiceImplTest {
                         .id(300L)
                         .missionItemId(100L)
                         .actorId(1L)
-                        .actionType(MissionLogActionType.CREATED)
+                        .actionType(MissionLogActionType.MISSION_CREATED)
                         .message("Mission created")
                         .build();
         MissionItem mission = mission(100L, 10L, 2L, 1L, reward(900L, 500L), "clean room");
@@ -164,7 +164,7 @@ class MissionServiceImplTest {
 
         assertThat(result.missions()).hasSize(1);
         assertThat(result.missions().getFirst().logId()).isEqualTo(300L);
-        assertThat(result.missions().getFirst().actionType()).isEqualTo("CREATED");
+        assertThat(result.missions().getFirst().actionType()).isEqualTo("MISSION_CREATED");
         assertThat(result.missions().getFirst().missionItem().reward().rewardId()).isEqualTo(900L);
         verify(missionLogRepository).findByFamilyScope(10L, null, PageRequest.of(0, 21));
     }

--- a/src/test/java/com/project/domain/reward/controller/RewardControllerIntegrationTest.java
+++ b/src/test/java/com/project/domain/reward/controller/RewardControllerIntegrationTest.java
@@ -178,7 +178,9 @@ class RewardControllerIntegrationTest {
                         .readTree(respondResult.getResponse().getContentAsString())
                         .path("data");
         assertRewardNode(
-                respondData.path("missionItem").path("reward"), rewardTemplate.getId(), "data reward");
+                respondData.path("missionItem").path("reward"),
+                rewardTemplate.getId(),
+                "data reward");
 
         MvcResult receivedResult =
                 mockMvc.perform(
@@ -194,7 +196,9 @@ class RewardControllerIntegrationTest {
                         .path("rewards")
                         .get(0);
         assertRewardNode(
-                receivedNode.path("missionItem").path("reward"), rewardTemplate.getId(), "data reward");
+                receivedNode.path("missionItem").path("reward"),
+                rewardTemplate.getId(),
+                "data reward");
     }
 
     @Test

--- a/src/test/java/com/project/domain/reward/controller/RewardControllerIntegrationTest.java
+++ b/src/test/java/com/project/domain/reward/controller/RewardControllerIntegrationTest.java
@@ -178,9 +178,7 @@ class RewardControllerIntegrationTest {
                         .readTree(respondResult.getResponse().getContentAsString())
                         .path("data");
         assertRewardNode(
-                respondData.path("missionItem").path("reward"),
-                rewardTemplate.getId(),
-                "data reward");
+                respondData.path("missionItem").path("reward"), rewardTemplate.getId(), "data reward");
 
         MvcResult receivedResult =
                 mockMvc.perform(
@@ -196,9 +194,7 @@ class RewardControllerIntegrationTest {
                         .path("rewards")
                         .get(0);
         assertRewardNode(
-                receivedNode.path("missionItem").path("reward"),
-                rewardTemplate.getId(),
-                "data reward");
+                receivedNode.path("missionItem").path("reward"), rewardTemplate.getId(), "data reward");
     }
 
     @Test
@@ -244,5 +240,6 @@ class RewardControllerIntegrationTest {
         assertThat(rewardNode.has("rewardId")).isTrue();
         assertThat(rewardNode.path("templateId").asLong()).isEqualTo(templateId);
         assertThat(rewardNode.path("name").asText()).isEqualTo(expectedName);
+        assertThat(rewardNode.has("rewardValue")).isFalse();
     }
 }


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

<!-- 이슈 넘버와 티켓 넘버를 작성해주세요. 이슈가 닫히는 것을 원치 않으면 closed:를 지워주세요 -->

- closed: #81 
- jira: DABOM-287

---

## 🎯 목적

<!-- 왜 이 변경이 필요한지 배경과 목적을 작성해주세요. -->
- OWNER의 이의제기 승인/거절
- MEMBER의 이의제기 취소
- 가족 구성원의 댓글 작성

이번 변경은 위 3개 기능을 서비스/컨트롤러/응답 DTO 기준으로 완성하는 데 목적이 있다.

## 📝 변경 사항

<!-- 무엇을 변경했는지 리스트로 작성해주세요. -->
- `PATCH /appeals/{appealId}/respond` 추가
- `PATCH /appeals/{appealId}/cancel` 추가
- `POST /appeals/{appealId}/comments` 추가
- 이의제기 승인/거절 요청 DTO 추가
- 댓글 작성 요청 DTO 추가
- 승인/거절 응답 DTO 추가
- 댓글 작성 응답 DTO 추가
- 취소 응답 DTO 추가
- `PolicyAppeal` 상태 전이 메서드 추가
- 승인 시 `desiredRules`가 있으면 `PolicyAssignment.rules`에 반영
- 댓글 작성 응답에 `authorId`, `authorName` 포함
- `AppealServiceImplTest`에 승인/거절, 취소, 댓글 작성 테스트 추가

추가된 API는 아래 역할에 대응한다.

- OWNER: 이의제기 승인/거절
- MEMBER: 본인 이의제기 취소
- OWNER + MEMBER: 같은 가족 이의제기에 댓글 작성

## 📂 변경 범위

<!-- 변경된 도메인/레이어를 표시해주세요. 해당 항목에 [x]로 체크해주세요. -->

| 도메인 | controller | service | repository | entity | dto/model | test |
| :----: | :--------: | :-----: | :--------: | :----: | :-------: | :--: |
| appeal |     x      |    x    |            |   x    |     x     |  x   |
| policy |            |    x    |            |        |           |  x   |

---

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. 단순 변경이면 섹션을 지워도 됩니다. -->

```java
// 코드는 이 사이에 작성하면 됩니다.
@OwnerOnly
@PatchMapping("/{appealId}/respond")
public ApiResponse<AppealRespondResponse> respondAppeal(
        @CustomerId Long customerId,
        @PathVariable Long appealId,
        @RequestBody @Valid AppealRespondRequest request) {
    AuthContext auth = authContextService.resolve(customerId);
    AppealRespondResult result = appealService.respondAppeal(auth, appealId, request);
    return ApiResponse.success(AppealRespondResponse.from(result));
}
```
처리 규칙:

- OWNER만 가능
- 같은 가족 이의제기만 처리 가능
- `PENDING` 상태만 처리 가능
- `APPROVED` 시 `resolvedById`, `resolvedAt` 기록
- `desiredRules`가 있으면 `PolicyAssignment.rules`에도 반영
- `REJECTED` 시 `rejectReason`, `resolvedById`, `resolvedAt` 기록

승인 응답 예시:

```json
{
  "appealId": 101,
  "status": "APPROVED",
  "rejectReason": null,
  "resolvedById": 1,
  "resolvedAt": "2026-03-11T21:00:00"
}
```


## 💬 리뷰어에게

<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
- 승인 시 `desiredRules` 반영은 `PolicyAssignment.update()`를 통해 현재 assignment의 `rules`만 갱신하도록 구현했다.
- `AppealRespondRequest.action`은 문자열을 받아 `APPROVED`, `REJECTED`만 허용한다.
- 댓글 생성 응답은 UI에서 별도 고객 조회 없이 바로 표시할 수 있도록 `authorId`, `authorName`을 함께 반환한다.
- 현재 알림 발행은 이번 PR 범위에 포함하지 않았다.
---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

**기본**
- [x] 승인/거절, 취소, 댓글 작성 API가 모두 추가되었는가?
- [x] DTO와 결과 모델이 기능별로 분리되었는가?

**코드 작성**
- [x] 승인/거절은 OWNER만 가능하도록 처리되었는가?
- [x] 취소는 MEMBER의 본인 `NORMAL + PENDING` 이의제기만 가능하도록 처리되었는가?
- [x] 댓글은 같은 가족 구성원만 가능하도록 처리되었는가?
- [x] 댓글 응답에 작성자 이름이 포함되는가?

**테스트**
- [x] 승인 시 상태 변경과 `desiredRules` 반영 테스트가 있는가?
- [x] 거절 시 `rejectReason` 기록 테스트가 있는가?
- [x] 취소 시 `CANCELLED` 전이 테스트가 있는가?
- [x] 댓글 작성 응답에 `authorId`, `authorName`이 검증되는가?

## 📌 참고 사항

<!-- 추가로 공유할 내용이 있으면 작성해주세요. (관련 문서 링크, 후속 작업 등) -->
