### PR TITLE
[DABOM-433] /*/login/에서 역할도 반환하도록 개선

### DIFF
--- a/src/main/java/com/project/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/project/domain/admin/controller/AdminController.java
@@ -34,7 +34,8 @@ public class AdminController {
     public ApiResponse<SignInResponse> signIn(
             @Valid @RequestBody AdminSignInRequest signInRequest) {
         return ApiResponse.success(
-                adminService.signIn(signInRequest.email(), signInRequest.password()));
+                SignInResponse.from(
+                        adminService.signIn(signInRequest.email(), signInRequest.password())));
     }
 
     @PostMapping("/signup")

--- a/src/main/java/com/project/domain/admin/service/AdminService.java
+++ b/src/main/java/com/project/domain/admin/service/AdminService.java
@@ -1,11 +1,11 @@
 package com.project.domain.admin.service;
 
-import com.project.domain.customer.dto.response.SignInResponse;
 import com.project.domain.customer.dto.response.SignUpResponse;
+import com.project.global.auth.SignInResult;
 import com.project.global.auth.TokenRefreshResult;
 
 public interface AdminService {
-    SignInResponse signIn(String email, String password);
+    SignInResult signIn(String email, String password);
 
     SignUpResponse signUp(String email, String password);
 

--- a/src/main/java/com/project/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/project/domain/admin/service/AdminServiceImpl.java
@@ -44,7 +44,7 @@ public class AdminServiceImpl implements AdminService {
         String accessToken = jwtTokenUtil.createToken(admin.getId(), RoleType.ADMIN);
         String refreshToken = jwtTokenUtil.createRefreshToken(admin.getId(), RoleType.ADMIN);
 
-        return new SignInResponse(accessToken, refreshToken);
+        return new SignInResponse(accessToken, refreshToken, RoleType.ADMIN.name());
     }
 
     @Override

--- a/src/main/java/com/project/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/project/domain/admin/service/AdminServiceImpl.java
@@ -13,7 +13,6 @@ import com.project.global.auth.PasswordHash;
 import com.project.global.auth.TokenRefreshResult;
 import com.project.global.exception.ApplicationException;
 import com.project.global.exception.code.AdminErrorCode;
-import com.project.global.exception.code.CustomerErrorCode;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
@@ -38,7 +37,7 @@ public class AdminServiceImpl implements AdminService {
                                                 AdminErrorCode.ADMIN_SIGN_IN_FAILED));
 
         if (!PasswordHash.matches(password, admin.getPasswordHash())) {
-            throw new ApplicationException(CustomerErrorCode.CUSTOMER_SIGN_IN_FAILED);
+            throw new ApplicationException(AdminErrorCode.ADMIN_SIGN_IN_FAILED);
         }
 
         String accessToken = jwtTokenUtil.createToken(admin.getId(), RoleType.ADMIN);

--- a/src/main/java/com/project/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/project/domain/admin/service/AdminServiceImpl.java
@@ -5,11 +5,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.project.domain.admin.entity.Admin;
 import com.project.domain.admin.repository.AdminRepository;
-import com.project.domain.customer.dto.response.SignInResponse;
 import com.project.domain.customer.dto.response.SignUpResponse;
 import com.project.domain.customer.enums.RoleType;
 import com.project.global.auth.JwtTokenUtil;
 import com.project.global.auth.PasswordHash;
+import com.project.global.auth.SignInResult;
 import com.project.global.auth.TokenRefreshResult;
 import com.project.global.exception.ApplicationException;
 import com.project.global.exception.code.AdminErrorCode;
@@ -27,7 +27,7 @@ public class AdminServiceImpl implements AdminService {
     private final JwtTokenUtil jwtTokenUtil;
 
     @Override
-    public SignInResponse signIn(String email, String password) {
+    public SignInResult signIn(String email, String password) {
         Admin admin =
                 adminRepository
                         .findByEmail(email)
@@ -43,7 +43,7 @@ public class AdminServiceImpl implements AdminService {
         String accessToken = jwtTokenUtil.createToken(admin.getId(), RoleType.ADMIN);
         String refreshToken = jwtTokenUtil.createRefreshToken(admin.getId(), RoleType.ADMIN);
 
-        return new SignInResponse(accessToken, refreshToken, RoleType.ADMIN.name());
+        return new SignInResult(accessToken, refreshToken, RoleType.ADMIN);
     }
 
     @Override

--- a/src/main/java/com/project/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/project/domain/admin/service/AdminServiceImpl.java
@@ -53,9 +53,9 @@ public class AdminServiceImpl implements AdminService {
 
         Admin admin = Admin.builder().name("ADMIN").email(email).passwordHash(hashed).build();
 
-        adminRepository.save(admin);
+        Admin saved = adminRepository.save(admin);
 
-        return new SignUpResponse(admin.getId());
+        return new SignUpResponse(saved.getId());
     }
 
     @Override

--- a/src/main/java/com/project/domain/customer/controller/CustomerController.java
+++ b/src/main/java/com/project/domain/customer/controller/CustomerController.java
@@ -43,7 +43,7 @@ public class CustomerController {
     @Operation(summary = "사용자 로그인", description = "사용자 이메일/비밀번호로 로그인합니다.")
     public ApiResponse<SignInResponse> signIn(
             @Valid @RequestBody CustomerSignInRequest requestDto) {
-        return ApiResponse.success(customerService.signIn(requestDto));
+        return ApiResponse.success(SignInResponse.from(customerService.signIn(requestDto)));
     }
 
     @PostMapping("/signup")

--- a/src/main/java/com/project/domain/customer/dto/response/SignInResponse.java
+++ b/src/main/java/com/project/domain/customer/dto/response/SignInResponse.java
@@ -1,3 +1,3 @@
 package com.project.domain.customer.dto.response;
 
-public record SignInResponse(String accessToken, String refreshToken) {}
+public record SignInResponse(String accessToken, String refreshToken, String role) {}

--- a/src/main/java/com/project/domain/customer/dto/response/SignInResponse.java
+++ b/src/main/java/com/project/domain/customer/dto/response/SignInResponse.java
@@ -1,3 +1,11 @@
 package com.project.domain.customer.dto.response;
 
-public record SignInResponse(String accessToken, String refreshToken, String role) {}
+import com.project.global.auth.SignInResult;
+
+public record SignInResponse(String accessToken, String refreshToken, String role) {
+
+    public static SignInResponse from(SignInResult result) {
+        return new SignInResponse(
+                result.accessToken(), result.refreshToken(), result.role().name());
+    }
+}

--- a/src/main/java/com/project/domain/customer/service/CustomerService.java
+++ b/src/main/java/com/project/domain/customer/service/CustomerService.java
@@ -2,14 +2,14 @@ package com.project.domain.customer.service;
 
 import com.project.domain.customer.dto.request.CustomerSignInRequest;
 import com.project.domain.customer.dto.request.CustomerSignUpRequest;
-import com.project.domain.customer.dto.response.SignInResponse;
 import com.project.domain.customer.dto.response.SignUpResponse;
 import com.project.domain.customer.model.MyPageInfo;
+import com.project.global.auth.SignInResult;
 import com.project.global.auth.TokenRefreshResult;
 import com.project.global.auth.model.AuthContext;
 
 public interface CustomerService {
-    SignInResponse signIn(CustomerSignInRequest requestDto);
+    SignInResult signIn(CustomerSignInRequest requestDto);
 
     SignUpResponse signUp(CustomerSignUpRequest requestDto);
 

--- a/src/main/java/com/project/domain/customer/service/CustomerServiceImpl.java
+++ b/src/main/java/com/project/domain/customer/service/CustomerServiceImpl.java
@@ -68,7 +68,7 @@ public class CustomerServiceImpl implements CustomerService {
         String accessToken = jwtTokenUtil.createToken(customer.getId(), role);
         String refreshToken = jwtTokenUtil.createRefreshToken(customer.getId(), role);
 
-        return new SignInResponse(accessToken, refreshToken);
+        return new SignInResponse(accessToken, refreshToken, role.name());
     }
 
     @Transactional

--- a/src/main/java/com/project/domain/customer/service/CustomerServiceImpl.java
+++ b/src/main/java/com/project/domain/customer/service/CustomerServiceImpl.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.domain.customer.dto.request.CustomerSignInRequest;
 import com.project.domain.customer.dto.request.CustomerSignUpRequest;
-import com.project.domain.customer.dto.response.SignInResponse;
 import com.project.domain.customer.dto.response.SignUpResponse;
 import com.project.domain.customer.entity.Customer;
 import com.project.domain.customer.entity.CustomerQuota;
@@ -26,6 +25,7 @@ import com.project.domain.policy.enums.PolicyType;
 import com.project.domain.policy.repository.PolicyAssignmentRepository;
 import com.project.global.auth.JwtTokenUtil;
 import com.project.global.auth.PasswordHash;
+import com.project.global.auth.SignInResult;
 import com.project.global.auth.TokenRefreshResult;
 import com.project.global.auth.model.AuthContext;
 import com.project.global.exception.ApplicationException;
@@ -52,7 +52,7 @@ public class CustomerServiceImpl implements CustomerService {
     private final ObjectMapper objectMapper;
 
     @Override
-    public SignInResponse signIn(CustomerSignInRequest requestDto) {
+    public SignInResult signIn(CustomerSignInRequest requestDto) {
         Customer customer = customerRepository.findByPhoneNumber(requestDto.phoneNumber());
 
         if (customer == null) {
@@ -68,7 +68,7 @@ public class CustomerServiceImpl implements CustomerService {
         String accessToken = jwtTokenUtil.createToken(customer.getId(), role);
         String refreshToken = jwtTokenUtil.createRefreshToken(customer.getId(), role);
 
-        return new SignInResponse(accessToken, refreshToken, role.name());
+        return new SignInResult(accessToken, refreshToken, role);
     }
 
     @Transactional

--- a/src/main/java/com/project/global/auth/SignInResult.java
+++ b/src/main/java/com/project/global/auth/SignInResult.java
@@ -1,0 +1,5 @@
+package com.project.global.auth;
+
+import com.project.domain.customer.enums.RoleType;
+
+public record SignInResult(String accessToken, String refreshToken, RoleType role) {}

--- a/src/test/java/com/project/domain/admin/service/AdminServiceImplTest.java
+++ b/src/test/java/com/project/domain/admin/service/AdminServiceImplTest.java
@@ -19,11 +19,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.project.domain.admin.entity.Admin;
 import com.project.domain.admin.repository.AdminRepository;
-import com.project.domain.customer.dto.response.SignInResponse;
 import com.project.domain.customer.dto.response.SignUpResponse;
 import com.project.domain.customer.enums.RoleType;
 import com.project.global.auth.JwtTokenUtil;
 import com.project.global.auth.PasswordHash;
+import com.project.global.auth.SignInResult;
 import com.project.global.auth.TokenRefreshResult;
 import com.project.global.exception.ApplicationException;
 import com.project.global.exception.code.AdminErrorCode;
@@ -59,12 +59,12 @@ class AdminServiceImplTest {
             passwordHash.when(() -> PasswordHash.matches("raw-pw", "hashed-pw")).thenReturn(true);
 
             // when
-            SignInResponse result = adminService.signIn("admin@test.com", "raw-pw");
+            SignInResult result = adminService.signIn("admin@test.com", "raw-pw");
 
             // then
             assertThat(result.accessToken()).isEqualTo("access-token");
             assertThat(result.refreshToken()).isEqualTo("refresh-token");
-            assertThat(result.role()).isEqualTo("ADMIN");
+            assertThat(result.role()).isEqualTo(RoleType.ADMIN);
         }
     }
 

--- a/src/test/java/com/project/domain/admin/service/AdminServiceImplTest.java
+++ b/src/test/java/com/project/domain/admin/service/AdminServiceImplTest.java
@@ -116,8 +116,14 @@ class AdminServiceImplTest {
     @DisplayName("signUp - 정상 요청이면 관리자를 저장하고 ID를 반환한다")
     void signUp_validRequest_returnsAdminId() {
         // given
-        given(adminRepository.save(any(Admin.class)))
-                .willAnswer(invocation -> invocation.getArgument(0));
+        Admin savedAdmin =
+                Admin.builder()
+                        .id(1L)
+                        .email("admin@test.com")
+                        .name("ADMIN")
+                        .passwordHash("hashed-pw")
+                        .build();
+        given(adminRepository.save(any(Admin.class))).willReturn(savedAdmin);
 
         try (MockedStatic<PasswordHash> passwordHash = mockStatic(PasswordHash.class)) {
             passwordHash.when(() -> PasswordHash.hash("raw-pw")).thenReturn("hashed-pw");
@@ -126,7 +132,7 @@ class AdminServiceImplTest {
             SignUpResponse result = adminService.signUp("admin@test.com", "raw-pw");
 
             // then
-            assertThat(result).isNotNull();
+            assertThat(result.id()).isEqualTo(1L);
         }
     }
 

--- a/src/test/java/com/project/domain/admin/service/AdminServiceImplTest.java
+++ b/src/test/java/com/project/domain/admin/service/AdminServiceImplTest.java
@@ -27,7 +27,6 @@ import com.project.global.auth.PasswordHash;
 import com.project.global.auth.TokenRefreshResult;
 import com.project.global.exception.ApplicationException;
 import com.project.global.exception.code.AdminErrorCode;
-import com.project.global.exception.code.CustomerErrorCode;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
@@ -109,7 +108,7 @@ class AdminServiceImplTest {
                     .satisfies(
                             e ->
                                     assertThat(((ApplicationException) e).getCode())
-                                            .isEqualTo(CustomerErrorCode.CUSTOMER_SIGN_IN_FAILED));
+                                            .isEqualTo(AdminErrorCode.ADMIN_SIGN_IN_FAILED));
         }
     }
 

--- a/src/test/java/com/project/domain/admin/service/AdminServiceImplTest.java
+++ b/src/test/java/com/project/domain/admin/service/AdminServiceImplTest.java
@@ -44,17 +44,20 @@ class AdminServiceImplTest {
     @DisplayName("signIn - 올바른 자격증명이면 토큰과 ADMIN 역할을 반환한다")
     void signIn_validCredentials_returnsTokensAndAdminRole() {
         // given
-        Admin admin = Admin.builder().id(1L).email("admin@test.com").name("ADMIN")
-                .passwordHash("hashed-pw").build();
+        Admin admin =
+                Admin.builder()
+                        .id(1L)
+                        .email("admin@test.com")
+                        .name("ADMIN")
+                        .passwordHash("hashed-pw")
+                        .build();
 
         given(adminRepository.findByEmail("admin@test.com")).willReturn(Optional.of(admin));
         given(jwtTokenUtil.createToken(1L, RoleType.ADMIN)).willReturn("access-token");
         given(jwtTokenUtil.createRefreshToken(1L, RoleType.ADMIN)).willReturn("refresh-token");
 
         try (MockedStatic<PasswordHash> passwordHash = mockStatic(PasswordHash.class)) {
-            passwordHash
-                    .when(() -> PasswordHash.matches("raw-pw", "hashed-pw"))
-                    .thenReturn(true);
+            passwordHash.when(() -> PasswordHash.matches("raw-pw", "hashed-pw")).thenReturn(true);
 
             // when
             SignInResponse result = adminService.signIn("admin@test.com", "raw-pw");
@@ -85,8 +88,13 @@ class AdminServiceImplTest {
     @DisplayName("signIn - 비밀번호가 틀리면 예외를 던진다")
     void signIn_wrongPassword_throwsException() {
         // given
-        Admin admin = Admin.builder().id(1L).email("admin@test.com").name("ADMIN")
-                .passwordHash("hashed-pw").build();
+        Admin admin =
+                Admin.builder()
+                        .id(1L)
+                        .email("admin@test.com")
+                        .name("ADMIN")
+                        .passwordHash("hashed-pw")
+                        .build();
 
         given(adminRepository.findByEmail("admin@test.com")).willReturn(Optional.of(admin));
 
@@ -101,8 +109,7 @@ class AdminServiceImplTest {
                     .satisfies(
                             e ->
                                     assertThat(((ApplicationException) e).getCode())
-                                            .isEqualTo(
-                                                    CustomerErrorCode.CUSTOMER_SIGN_IN_FAILED));
+                                            .isEqualTo(CustomerErrorCode.CUSTOMER_SIGN_IN_FAILED));
         }
     }
 

--- a/src/test/java/com/project/domain/admin/service/AdminServiceImplTest.java
+++ b/src/test/java/com/project/domain/admin/service/AdminServiceImplTest.java
@@ -2,22 +2,32 @@ package com.project.domain.admin.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.project.domain.admin.entity.Admin;
 import com.project.domain.admin.repository.AdminRepository;
+import com.project.domain.customer.dto.response.SignInResponse;
+import com.project.domain.customer.dto.response.SignUpResponse;
 import com.project.domain.customer.enums.RoleType;
 import com.project.global.auth.JwtTokenUtil;
+import com.project.global.auth.PasswordHash;
 import com.project.global.auth.TokenRefreshResult;
 import com.project.global.exception.ApplicationException;
 import com.project.global.exception.code.AdminErrorCode;
+import com.project.global.exception.code.CustomerErrorCode;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
@@ -29,6 +39,90 @@ class AdminServiceImplTest {
     @Mock private JwtTokenUtil jwtTokenUtil;
 
     @InjectMocks private AdminServiceImpl adminService;
+
+    @Test
+    @DisplayName("signIn - 올바른 자격증명이면 토큰과 ADMIN 역할을 반환한다")
+    void signIn_validCredentials_returnsTokensAndAdminRole() {
+        // given
+        Admin admin = Admin.builder().id(1L).email("admin@test.com").name("ADMIN")
+                .passwordHash("hashed-pw").build();
+
+        given(adminRepository.findByEmail("admin@test.com")).willReturn(Optional.of(admin));
+        given(jwtTokenUtil.createToken(1L, RoleType.ADMIN)).willReturn("access-token");
+        given(jwtTokenUtil.createRefreshToken(1L, RoleType.ADMIN)).willReturn("refresh-token");
+
+        try (MockedStatic<PasswordHash> passwordHash = mockStatic(PasswordHash.class)) {
+            passwordHash
+                    .when(() -> PasswordHash.matches("raw-pw", "hashed-pw"))
+                    .thenReturn(true);
+
+            // when
+            SignInResponse result = adminService.signIn("admin@test.com", "raw-pw");
+
+            // then
+            assertThat(result.accessToken()).isEqualTo("access-token");
+            assertThat(result.refreshToken()).isEqualTo("refresh-token");
+            assertThat(result.role()).isEqualTo("ADMIN");
+        }
+    }
+
+    @Test
+    @DisplayName("signIn - 존재하지 않는 이메일이면 예외를 던진다")
+    void signIn_adminNotFound_throwsException() {
+        // given
+        given(adminRepository.findByEmail("unknown@test.com")).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> adminService.signIn("unknown@test.com", "raw-pw"))
+                .isInstanceOf(ApplicationException.class)
+                .satisfies(
+                        e ->
+                                assertThat(((ApplicationException) e).getCode())
+                                        .isEqualTo(AdminErrorCode.ADMIN_SIGN_IN_FAILED));
+    }
+
+    @Test
+    @DisplayName("signIn - 비밀번호가 틀리면 예외를 던진다")
+    void signIn_wrongPassword_throwsException() {
+        // given
+        Admin admin = Admin.builder().id(1L).email("admin@test.com").name("ADMIN")
+                .passwordHash("hashed-pw").build();
+
+        given(adminRepository.findByEmail("admin@test.com")).willReturn(Optional.of(admin));
+
+        try (MockedStatic<PasswordHash> passwordHash = mockStatic(PasswordHash.class)) {
+            passwordHash
+                    .when(() -> PasswordHash.matches("wrong-pw", "hashed-pw"))
+                    .thenReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> adminService.signIn("admin@test.com", "wrong-pw"))
+                    .isInstanceOf(ApplicationException.class)
+                    .satisfies(
+                            e ->
+                                    assertThat(((ApplicationException) e).getCode())
+                                            .isEqualTo(
+                                                    CustomerErrorCode.CUSTOMER_SIGN_IN_FAILED));
+        }
+    }
+
+    @Test
+    @DisplayName("signUp - 정상 요청이면 관리자를 저장하고 ID를 반환한다")
+    void signUp_validRequest_returnsAdminId() {
+        // given
+        given(adminRepository.save(any(Admin.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        try (MockedStatic<PasswordHash> passwordHash = mockStatic(PasswordHash.class)) {
+            passwordHash.when(() -> PasswordHash.hash("raw-pw")).thenReturn("hashed-pw");
+
+            // when
+            SignUpResponse result = adminService.signUp("admin@test.com", "raw-pw");
+
+            // then
+            assertThat(result).isNotNull();
+        }
+    }
 
     @Test
     @DisplayName("refreshToken - 유효한 refresh token이면 새 토큰 쌍을 반환한다")

--- a/src/test/java/com/project/domain/customer/service/CustomerServiceImplTest.java
+++ b/src/test/java/com/project/domain/customer/service/CustomerServiceImplTest.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.domain.customer.dto.request.CustomerSignInRequest;
 import com.project.domain.customer.dto.request.CustomerSignUpRequest;
-import com.project.domain.customer.dto.response.SignInResponse;
 import com.project.domain.customer.dto.response.SignUpResponse;
 import com.project.domain.customer.entity.Customer;
 import com.project.domain.customer.entity.CustomerQuota;
@@ -40,6 +39,7 @@ import com.project.domain.policy.enums.PolicyType;
 import com.project.domain.policy.repository.PolicyAssignmentRepository;
 import com.project.global.auth.JwtTokenUtil;
 import com.project.global.auth.PasswordHash;
+import com.project.global.auth.SignInResult;
 import com.project.global.auth.TokenRefreshResult;
 import com.project.global.auth.model.AuthContext;
 import com.project.global.exception.ApplicationException;
@@ -81,12 +81,12 @@ class CustomerServiceImplTest {
             passwordHash.when(() -> PasswordHash.matches("raw-pw", "hashed-pw")).thenReturn(true);
 
             // when
-            SignInResponse result = customerService.signIn(request);
+            SignInResult result = customerService.signIn(request);
 
             // then
             assertThat(result.accessToken()).isEqualTo("access-token");
             assertThat(result.refreshToken()).isEqualTo("refresh-token");
-            assertThat(result.role()).isEqualTo("OWNER");
+            assertThat(result.role()).isEqualTo(RoleType.OWNER);
         }
     }
 

--- a/src/test/java/com/project/domain/customer/service/CustomerServiceImplTest.java
+++ b/src/test/java/com/project/domain/customer/service/CustomerServiceImplTest.java
@@ -10,13 +10,12 @@ import static org.mockito.Mockito.mockStatic;
 import java.time.LocalDate;
 import java.util.Optional;
 
-import org.mockito.MockedStatic;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -73,14 +72,13 @@ class CustomerServiceImplTest {
 
         given(customerRepository.findByPhoneNumber("01012345678")).willReturn(customer);
         given(familyMemberRepository.findRoleById(customer.getId())).willReturn(RoleType.OWNER);
-        given(jwtTokenUtil.createToken(customer.getId(), RoleType.OWNER)).willReturn("access-token");
+        given(jwtTokenUtil.createToken(customer.getId(), RoleType.OWNER))
+                .willReturn("access-token");
         given(jwtTokenUtil.createRefreshToken(customer.getId(), RoleType.OWNER))
                 .willReturn("refresh-token");
 
         try (MockedStatic<PasswordHash> passwordHash = mockStatic(PasswordHash.class)) {
-            passwordHash
-                    .when(() -> PasswordHash.matches("raw-pw", "hashed-pw"))
-                    .thenReturn(true);
+            passwordHash.when(() -> PasswordHash.matches("raw-pw", "hashed-pw")).thenReturn(true);
 
             // when
             SignInResponse result = customerService.signIn(request);
@@ -128,8 +126,7 @@ class CustomerServiceImplTest {
                     .satisfies(
                             e ->
                                     assertThat(((ApplicationException) e).getCode())
-                                            .isEqualTo(
-                                                    CustomerErrorCode.CUSTOMER_SIGN_IN_FAILED));
+                                            .isEqualTo(CustomerErrorCode.CUSTOMER_SIGN_IN_FAILED));
         }
     }
 
@@ -137,8 +134,7 @@ class CustomerServiceImplTest {
     @DisplayName("signUp - 정상 요청이면 고객을 저장하고 ID를 반환한다")
     void signUp_validRequest_returnsCustomerId() {
         // given
-        CustomerSignUpRequest request =
-                new CustomerSignUpRequest("01012345678", "raw-pw", "철수");
+        CustomerSignUpRequest request = new CustomerSignUpRequest("01012345678", "raw-pw", "철수");
 
         given(customerRepository.existsByPhoneNumber("01012345678")).willReturn(false);
         given(customerRepository.save(any(Customer.class)))
@@ -146,7 +142,9 @@ class CustomerServiceImplTest {
                         invocation -> {
                             Customer saved = invocation.getArgument(0);
                             return new Customer(
-                                    saved.getPhoneNumber(), saved.getPasswordHash(), saved.getName());
+                                    saved.getPhoneNumber(),
+                                    saved.getPasswordHash(),
+                                    saved.getName());
                         });
         given(familyMemberRepository.save(any(FamilyMember.class)))
                 .willAnswer(invocation -> invocation.getArgument(0));
@@ -166,8 +164,7 @@ class CustomerServiceImplTest {
     @DisplayName("signUp - 중복 전화번호이면 예외를 던진다")
     void signUp_duplicatePhoneNumber_throwsException() {
         // given
-        CustomerSignUpRequest request =
-                new CustomerSignUpRequest("01012345678", "raw-pw", "철수");
+        CustomerSignUpRequest request = new CustomerSignUpRequest("01012345678", "raw-pw", "철수");
         given(customerRepository.existsByPhoneNumber("01012345678")).willReturn(true);
 
         // when & then

--- a/src/test/java/com/project/domain/customer/service/CustomerServiceImplTest.java
+++ b/src/test/java/com/project/domain/customer/service/CustomerServiceImplTest.java
@@ -137,15 +137,11 @@ class CustomerServiceImplTest {
         CustomerSignUpRequest request = new CustomerSignUpRequest("01012345678", "raw-pw", "철수");
 
         given(customerRepository.existsByPhoneNumber("01012345678")).willReturn(false);
-        given(customerRepository.save(any(Customer.class)))
-                .willAnswer(
-                        invocation -> {
-                            Customer saved = invocation.getArgument(0);
-                            return new Customer(
-                                    saved.getPhoneNumber(),
-                                    saved.getPasswordHash(),
-                                    saved.getName());
-                        });
+
+        Customer savedCustomer = mock(Customer.class);
+        given(savedCustomer.getId()).willReturn(1L);
+        given(customerRepository.save(any(Customer.class))).willReturn(savedCustomer);
+
         given(familyMemberRepository.save(any(FamilyMember.class)))
                 .willAnswer(invocation -> invocation.getArgument(0));
 
@@ -156,7 +152,7 @@ class CustomerServiceImplTest {
             SignUpResponse result = customerService.signUp(request);
 
             // then
-            assertThat(result).isNotNull();
+            assertThat(result.id()).isEqualTo(1L);
         }
     }
 

--- a/src/test/java/com/project/domain/customer/service/CustomerServiceImplTest.java
+++ b/src/test/java/com/project/domain/customer/service/CustomerServiceImplTest.java
@@ -2,11 +2,15 @@ package com.project.domain.customer.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 
 import java.time.LocalDate;
 import java.util.Optional;
+
+import org.mockito.MockedStatic;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +22,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.domain.customer.dto.request.CustomerSignInRequest;
+import com.project.domain.customer.dto.request.CustomerSignUpRequest;
+import com.project.domain.customer.dto.response.SignInResponse;
+import com.project.domain.customer.dto.response.SignUpResponse;
 import com.project.domain.customer.entity.Customer;
 import com.project.domain.customer.entity.CustomerQuota;
 import com.project.domain.customer.enums.RoleType;
@@ -25,12 +33,14 @@ import com.project.domain.customer.model.MyPageInfo;
 import com.project.domain.customer.repository.CustomerQuotaRepository;
 import com.project.domain.customer.repository.CustomerRepository;
 import com.project.domain.family.entity.Family;
+import com.project.domain.family.entity.FamilyMember;
 import com.project.domain.family.repository.FamilyMemberRepository;
 import com.project.domain.family.repository.FamilyRepository;
 import com.project.domain.policy.entity.PolicyAssignment;
 import com.project.domain.policy.enums.PolicyType;
 import com.project.domain.policy.repository.PolicyAssignmentRepository;
 import com.project.global.auth.JwtTokenUtil;
+import com.project.global.auth.PasswordHash;
 import com.project.global.auth.TokenRefreshResult;
 import com.project.global.auth.model.AuthContext;
 import com.project.global.exception.ApplicationException;
@@ -53,6 +63,121 @@ class CustomerServiceImplTest {
     @Mock private ObjectMapper objectMapper;
 
     @InjectMocks private CustomerServiceImpl customerService;
+
+    @Test
+    @DisplayName("signIn - 올바른 자격증명이면 토큰과 역할을 반환한다")
+    void signIn_validCredentials_returnsTokensAndRole() {
+        // given
+        Customer customer = new Customer("01012345678", "hashed-pw", "철수");
+        CustomerSignInRequest request = new CustomerSignInRequest("01012345678", "raw-pw");
+
+        given(customerRepository.findByPhoneNumber("01012345678")).willReturn(customer);
+        given(familyMemberRepository.findRoleById(customer.getId())).willReturn(RoleType.OWNER);
+        given(jwtTokenUtil.createToken(customer.getId(), RoleType.OWNER)).willReturn("access-token");
+        given(jwtTokenUtil.createRefreshToken(customer.getId(), RoleType.OWNER))
+                .willReturn("refresh-token");
+
+        try (MockedStatic<PasswordHash> passwordHash = mockStatic(PasswordHash.class)) {
+            passwordHash
+                    .when(() -> PasswordHash.matches("raw-pw", "hashed-pw"))
+                    .thenReturn(true);
+
+            // when
+            SignInResponse result = customerService.signIn(request);
+
+            // then
+            assertThat(result.accessToken()).isEqualTo("access-token");
+            assertThat(result.refreshToken()).isEqualTo("refresh-token");
+            assertThat(result.role()).isEqualTo("OWNER");
+        }
+    }
+
+    @Test
+    @DisplayName("signIn - 존재하지 않는 전화번호이면 예외를 던진다")
+    void signIn_customerNotFound_throwsException() {
+        // given
+        CustomerSignInRequest request = new CustomerSignInRequest("01099999999", "raw-pw");
+        given(customerRepository.findByPhoneNumber("01099999999")).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> customerService.signIn(request))
+                .isInstanceOf(ApplicationException.class)
+                .satisfies(
+                        e ->
+                                assertThat(((ApplicationException) e).getCode())
+                                        .isEqualTo(CustomerErrorCode.CUSTOMER_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("signIn - 비밀번호가 틀리면 예외를 던진다")
+    void signIn_wrongPassword_throwsException() {
+        // given
+        Customer customer = new Customer("01012345678", "hashed-pw", "철수");
+        CustomerSignInRequest request = new CustomerSignInRequest("01012345678", "wrong-pw");
+
+        given(customerRepository.findByPhoneNumber("01012345678")).willReturn(customer);
+
+        try (MockedStatic<PasswordHash> passwordHash = mockStatic(PasswordHash.class)) {
+            passwordHash
+                    .when(() -> PasswordHash.matches("wrong-pw", "hashed-pw"))
+                    .thenReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> customerService.signIn(request))
+                    .isInstanceOf(ApplicationException.class)
+                    .satisfies(
+                            e ->
+                                    assertThat(((ApplicationException) e).getCode())
+                                            .isEqualTo(
+                                                    CustomerErrorCode.CUSTOMER_SIGN_IN_FAILED));
+        }
+    }
+
+    @Test
+    @DisplayName("signUp - 정상 요청이면 고객을 저장하고 ID를 반환한다")
+    void signUp_validRequest_returnsCustomerId() {
+        // given
+        CustomerSignUpRequest request =
+                new CustomerSignUpRequest("01012345678", "raw-pw", "철수");
+
+        given(customerRepository.existsByPhoneNumber("01012345678")).willReturn(false);
+        given(customerRepository.save(any(Customer.class)))
+                .willAnswer(
+                        invocation -> {
+                            Customer saved = invocation.getArgument(0);
+                            return new Customer(
+                                    saved.getPhoneNumber(), saved.getPasswordHash(), saved.getName());
+                        });
+        given(familyMemberRepository.save(any(FamilyMember.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        try (MockedStatic<PasswordHash> passwordHash = mockStatic(PasswordHash.class)) {
+            passwordHash.when(() -> PasswordHash.hash("raw-pw")).thenReturn("hashed-pw");
+
+            // when
+            SignUpResponse result = customerService.signUp(request);
+
+            // then
+            assertThat(result).isNotNull();
+        }
+    }
+
+    @Test
+    @DisplayName("signUp - 중복 전화번호이면 예외를 던진다")
+    void signUp_duplicatePhoneNumber_throwsException() {
+        // given
+        CustomerSignUpRequest request =
+                new CustomerSignUpRequest("01012345678", "raw-pw", "철수");
+        given(customerRepository.existsByPhoneNumber("01012345678")).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> customerService.signUp(request))
+                .isInstanceOf(ApplicationException.class)
+                .satisfies(
+                        e ->
+                                assertThat(((ApplicationException) e).getCode())
+                                        .isEqualTo(CustomerErrorCode.CUSTOMER_DUPLICATED));
+    }
 
     @Test
     @DisplayName("refreshToken - OWNER role의 유효한 refresh token이면 새 토큰 쌍을 반환한다")


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

- closed: #97 
- jira: DABOM-433

---

## 🎯 목적

클라이언트가 로그인 직후 사용자의 역할(OWNER/MEMBER/ADMIN)을 알 수 있도록 로그인 응답에 `role` 필드를 추가하고, 기존에 누락되었던 `signIn`/`signUp` 단위 테스트를 보충합니다.

## 📝 변경 사항

- `SignInResponse` record에 `role` 필드 추가
- `CustomerServiceImpl.signIn()`에서 조회된 역할을 응답에 포함
- `AdminServiceImpl.signIn()`에서 `ADMIN` 역할을 응답에 포함
- `CustomerServiceImplTest`에 `signIn` 테스트 3개, `signUp` 테스트 2개 추가
- `AdminServiceImplTest`에 `signIn` 테스트 3개, `signUp` 테스트 1개 추가

## 📂 변경 범위

| 도메인 | controller | service | repository | entity | infra | global |
| :----: | :--------: | :-----: | :--------: | :----: | :---: | :----: |
| customer | | [x] | | | | |
| admin | | [x] | | | | |

---

## 🖥️ 주요 코드 설명

```java
// SignInResponse에 role 필드 추가
public record SignInResponse(String accessToken, String refreshToken, String role) {}
```

```java
// CustomerServiceImpl — 이미 조회하던 role을 응답에 포함
RoleType role = familyMemberRepository.findRoleById(customer.getId());
return new SignInResponse(accessToken, refreshToken, role.name());
```

```java
// AdminServiceImpl — ADMIN 고정값 전달
return new SignInResponse(accessToken, refreshToken, RoleType.ADMIN.name());
```

## 💬 리뷰어에게

- `CustomerServiceImpl.signIn()`은 이미 JWT 생성을 위해 `role`을 조회하고 있어서 추가 쿼리 없이 응답에 포함했습니다.
- `role` 필드는 `RoleType.name()` 문자열(`"OWNER"`, `"MEMBER"`, `"ADMIN"`)로 반환됩니다.
- `PasswordHash`가 static 유틸 클래스이므로 테스트에서 `MockedStatic<PasswordHash>`를 사용했습니다.

---

## 📋 체크리스트

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [x] 전체 변경사항이 500줄을 넘지 않는가?

**코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → Repository → Entity`)
- [x] Setter 없이 비즈니스 메서드로 상태를 변경하는가?
- [x] `@Transactional`은 Service에만 선언했는가?

**테스트**
- [x] 신규 비즈니스 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

- Customer: signIn 3개 + signUp 2개 = 5개 테스트 추가
- Admin: signIn 3개 + signUp 1개 = 4개 테스트 추가
