### PR TITLE
[DABOM-432] 토큰 없을 시 응답 추가 및 에러 응답 개선

### DIFF
--- a/src/main/java/com/project/global/auth/JwtTokenUtil.java
+++ b/src/main/java/com/project/global/auth/JwtTokenUtil.java
@@ -11,6 +11,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.project.domain.customer.enums.RoleType;
+import com.project.global.exception.ApplicationException;
+import com.project.global.exception.code.GlobalErrorCode;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -89,6 +91,17 @@ public class JwtTokenUtil {
     public RoleType getRole(String token) {
         String roleStr = verifyAccessToken(token).get("role", String.class);
         return RoleType.valueOf(roleStr);
+    }
+
+    public Claims getVerifiedClaims(String token) {
+        if (token == null || token.isBlank()) {
+            throw new ApplicationException(GlobalErrorCode.UNAUTHORIZED_TOKEN);
+        }
+        try {
+            return verifyAccessToken(token);
+        } catch (JwtException e) {
+            throw new ApplicationException(GlobalErrorCode.UNAUTHORIZED_TOKEN);
+        }
     }
 
     public Claims verifyAccessToken(String token) {

--- a/src/main/java/com/project/global/auth/LoginInterceptor.java
+++ b/src/main/java/com/project/global/auth/LoginInterceptor.java
@@ -8,6 +8,8 @@ import org.springframework.web.servlet.HandlerInterceptor;
 import com.project.global.exception.ApplicationException;
 import com.project.global.exception.code.GlobalErrorCode;
 
+import io.jsonwebtoken.JwtException;
+
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -23,7 +25,7 @@ public class LoginInterceptor implements HandlerInterceptor {
         }
         try {
             jwtTokenUtil.verifyAccessToken(token);
-        } catch (RuntimeException e) {
+        } catch (JwtException e) {
             throw new ApplicationException(GlobalErrorCode.UNAUTHORIZED_TOKEN);
         }
         return true;

--- a/src/main/java/com/project/global/auth/LoginInterceptor.java
+++ b/src/main/java/com/project/global/auth/LoginInterceptor.java
@@ -5,6 +5,9 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.web.servlet.HandlerInterceptor;
 
+import com.project.global.exception.ApplicationException;
+import com.project.global.exception.code.GlobalErrorCode;
+
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -15,7 +18,14 @@ public class LoginInterceptor implements HandlerInterceptor {
     public boolean preHandle(
             HttpServletRequest request, HttpServletResponse response, Object handler) {
         final String token = AuthorizationExtractor.extract(request);
-        jwtTokenUtil.verifyAccessToken(token);
+        if (token == null || token.isBlank()) {
+            throw new ApplicationException(GlobalErrorCode.UNAUTHORIZED_TOKEN);
+        }
+        try {
+            jwtTokenUtil.verifyAccessToken(token);
+        } catch (RuntimeException e) {
+            throw new ApplicationException(GlobalErrorCode.UNAUTHORIZED_TOKEN);
+        }
         return true;
     }
 }

--- a/src/main/java/com/project/global/auth/LoginInterceptor.java
+++ b/src/main/java/com/project/global/auth/LoginInterceptor.java
@@ -5,11 +5,6 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.web.servlet.HandlerInterceptor;
 
-import com.project.global.exception.ApplicationException;
-import com.project.global.exception.code.GlobalErrorCode;
-
-import io.jsonwebtoken.JwtException;
-
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -20,14 +15,7 @@ public class LoginInterceptor implements HandlerInterceptor {
     public boolean preHandle(
             HttpServletRequest request, HttpServletResponse response, Object handler) {
         final String token = AuthorizationExtractor.extract(request);
-        if (token == null || token.isBlank()) {
-            throw new ApplicationException(GlobalErrorCode.UNAUTHORIZED_TOKEN);
-        }
-        try {
-            jwtTokenUtil.verifyAccessToken(token);
-        } catch (JwtException e) {
-            throw new ApplicationException(GlobalErrorCode.UNAUTHORIZED_TOKEN);
-        }
+        jwtTokenUtil.getVerifiedClaims(token);
         return true;
     }
 }

--- a/src/main/java/com/project/global/auth/aop/AdminOnlyAspect.java
+++ b/src/main/java/com/project/global/auth/aop/AdminOnlyAspect.java
@@ -15,6 +15,8 @@ import com.project.global.auth.JwtTokenUtil;
 import com.project.global.exception.ApplicationException;
 import com.project.global.exception.code.AdminErrorCode;
 
+import io.jsonwebtoken.JwtException;
+
 import lombok.RequiredArgsConstructor;
 
 @Aspect
@@ -38,7 +40,7 @@ public class AdminOnlyAspect {
         RoleType role;
         try {
             role = jwtTokenUtil.getRole(token);
-        } catch (RuntimeException e) {
+        } catch (JwtException e) {
             throw new ApplicationException(AdminErrorCode.ADMIN_UNAUTHORIZED);
         }
 

--- a/src/main/java/com/project/global/auth/aop/CustomerArgumentResolver.java
+++ b/src/main/java/com/project/global/auth/aop/CustomerArgumentResolver.java
@@ -10,10 +10,8 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 import com.project.global.auth.AuthorizationExtractor;
 import com.project.global.auth.JwtTokenUtil;
-import com.project.global.exception.ApplicationException;
-import com.project.global.exception.code.GlobalErrorCode;
 
-import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Claims;
 
 import lombok.RequiredArgsConstructor;
 
@@ -40,17 +38,7 @@ public class CustomerArgumentResolver implements HandlerMethodArgumentResolver {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
 
         String token = AuthorizationExtractor.extract(request);
-        if (token == null || token.isBlank()) {
-            throw new ApplicationException(GlobalErrorCode.UNAUTHORIZED_TOKEN);
-        }
-
-        Long id;
-        try {
-            id = jwtTokenUtil.getMemberId(token);
-        } catch (JwtException e) {
-            throw new ApplicationException(GlobalErrorCode.UNAUTHORIZED_TOKEN);
-        }
-
-        return id;
+        Claims claims = jwtTokenUtil.getVerifiedClaims(token);
+        return Long.parseLong(claims.getSubject());
     }
 }

--- a/src/main/java/com/project/global/auth/aop/CustomerArgumentResolver.java
+++ b/src/main/java/com/project/global/auth/aop/CustomerArgumentResolver.java
@@ -10,6 +10,8 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 import com.project.global.auth.AuthorizationExtractor;
 import com.project.global.auth.JwtTokenUtil;
+import com.project.global.exception.ApplicationException;
+import com.project.global.exception.code.GlobalErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -36,7 +38,16 @@ public class CustomerArgumentResolver implements HandlerMethodArgumentResolver {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
 
         String token = AuthorizationExtractor.extract(request);
-        Long id = jwtTokenUtil.getMemberId(token);
+        if (token == null || token.isBlank()) {
+            throw new ApplicationException(GlobalErrorCode.UNAUTHORIZED_TOKEN);
+        }
+
+        Long id;
+        try {
+            id = jwtTokenUtil.getMemberId(token);
+        } catch (RuntimeException e) {
+            throw new ApplicationException(GlobalErrorCode.UNAUTHORIZED_TOKEN);
+        }
 
         return id;
     }

--- a/src/main/java/com/project/global/auth/aop/CustomerArgumentResolver.java
+++ b/src/main/java/com/project/global/auth/aop/CustomerArgumentResolver.java
@@ -13,6 +13,8 @@ import com.project.global.auth.JwtTokenUtil;
 import com.project.global.exception.ApplicationException;
 import com.project.global.exception.code.GlobalErrorCode;
 
+import io.jsonwebtoken.JwtException;
+
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -45,7 +47,7 @@ public class CustomerArgumentResolver implements HandlerMethodArgumentResolver {
         Long id;
         try {
             id = jwtTokenUtil.getMemberId(token);
-        } catch (RuntimeException e) {
+        } catch (JwtException e) {
             throw new ApplicationException(GlobalErrorCode.UNAUTHORIZED_TOKEN);
         }
 

--- a/src/main/java/com/project/global/auth/aop/OwnerOnlyAspect.java
+++ b/src/main/java/com/project/global/auth/aop/OwnerOnlyAspect.java
@@ -16,6 +16,8 @@ import com.project.global.exception.ApplicationException;
 import com.project.global.exception.code.CustomerErrorCode;
 import com.project.global.exception.code.GlobalErrorCode;
 
+import io.jsonwebtoken.JwtException;
+
 import lombok.RequiredArgsConstructor;
 
 @Aspect
@@ -40,7 +42,7 @@ public class OwnerOnlyAspect {
         RoleType role;
         try {
             role = jwtTokenUtil.getRole(token);
-        } catch (RuntimeException e) {
+        } catch (JwtException e) {
             throw new ApplicationException(GlobalErrorCode.UNAUTHORIZED_TOKEN);
         }
 

--- a/src/main/java/com/project/global/auth/aop/OwnerOnlyAspect.java
+++ b/src/main/java/com/project/global/auth/aop/OwnerOnlyAspect.java
@@ -14,6 +14,7 @@ import com.project.global.auth.AuthorizationExtractor;
 import com.project.global.auth.JwtTokenUtil;
 import com.project.global.exception.ApplicationException;
 import com.project.global.exception.code.CustomerErrorCode;
+import com.project.global.exception.code.GlobalErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -32,8 +33,16 @@ public class OwnerOnlyAspect {
                         .getRequest();
 
         String token = AuthorizationExtractor.extract(request);
+        if (token == null || token.isBlank()) {
+            throw new ApplicationException(GlobalErrorCode.UNAUTHORIZED_TOKEN);
+        }
 
-        RoleType role = jwtTokenUtil.getRole(token);
+        RoleType role;
+        try {
+            role = jwtTokenUtil.getRole(token);
+        } catch (RuntimeException e) {
+            throw new ApplicationException(GlobalErrorCode.UNAUTHORIZED_TOKEN);
+        }
 
         if (role == RoleType.MEMBER) {
             throw new ApplicationException(CustomerErrorCode.CUSTOMER_FORBIDDEN);

--- a/src/main/java/com/project/global/auth/aop/OwnerOnlyAspect.java
+++ b/src/main/java/com/project/global/auth/aop/OwnerOnlyAspect.java
@@ -14,9 +14,8 @@ import com.project.global.auth.AuthorizationExtractor;
 import com.project.global.auth.JwtTokenUtil;
 import com.project.global.exception.ApplicationException;
 import com.project.global.exception.code.CustomerErrorCode;
-import com.project.global.exception.code.GlobalErrorCode;
 
-import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Claims;
 
 import lombok.RequiredArgsConstructor;
 
@@ -35,16 +34,8 @@ public class OwnerOnlyAspect {
                         .getRequest();
 
         String token = AuthorizationExtractor.extract(request);
-        if (token == null || token.isBlank()) {
-            throw new ApplicationException(GlobalErrorCode.UNAUTHORIZED_TOKEN);
-        }
-
-        RoleType role;
-        try {
-            role = jwtTokenUtil.getRole(token);
-        } catch (JwtException e) {
-            throw new ApplicationException(GlobalErrorCode.UNAUTHORIZED_TOKEN);
-        }
+        Claims claims = jwtTokenUtil.getVerifiedClaims(token);
+        RoleType role = RoleType.valueOf(claims.get("role", String.class));
 
         if (role == RoleType.MEMBER) {
             throw new ApplicationException(CustomerErrorCode.CUSTOMER_FORBIDDEN);

--- a/src/main/java/com/project/global/exception/ErrorResponse.java
+++ b/src/main/java/com/project/global/exception/ErrorResponse.java
@@ -1,3 +1,0 @@
-package com.project.global.exception;
-
-public record ErrorResponse(int status, String code, String message) {}

--- a/src/main/java/com/project/global/exception/ExceptionAdvice.java
+++ b/src/main/java/com/project/global/exception/ExceptionAdvice.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+import com.project.global.api.response.ApiResponse;
 import com.project.global.exception.code.BaseErrorCode;
 import com.project.global.exception.code.GlobalErrorCode;
 
@@ -23,11 +24,8 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         BaseErrorCode code = e.getCode();
         log.error("[BaseException] {} - {}", code.name(), code.getMessage());
 
-        ErrorResponse response =
-                new ErrorResponse(
-                        code.getHttpStatus().value(), code.getCustomCode(), code.getMessage());
-
-        return ResponseEntity.status(code.getHttpStatus()).body(response);
+        return ResponseEntity.status(code.getHttpStatus())
+                .body(ApiResponse.fail(code.getCustomCode(), code.getMessage(), null));
     }
 
     /** 그 외 모든 예외 */
@@ -37,10 +35,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
         GlobalErrorCode code = GlobalErrorCode.INTERNAL_SERVER_ERROR;
 
-        ErrorResponse response =
-                new ErrorResponse(
-                        code.getHttpStatus().value(), code.getCustomCode(), code.getMessage());
-
-        return ResponseEntity.status(code.getHttpStatus()).body(response);
+        return ResponseEntity.status(code.getHttpStatus())
+                .body(ApiResponse.fail(code.getCustomCode(), code.getMessage(), null));
     }
 }

--- a/src/main/java/com/project/global/exception/ExceptionAdvice.java
+++ b/src/main/java/com/project/global/exception/ExceptionAdvice.java
@@ -31,6 +31,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
     }
 
     /** 그 외 모든 예외 */
+    @ExceptionHandler(Exception.class)
     public ResponseEntity<Object> handleUnhandledException(Exception e, WebRequest request) {
         log.error("[Exception] Unhandled: {}", e.getMessage(), e);
 

--- a/src/main/java/com/project/global/exception/code/GlobalErrorCode.java
+++ b/src/main/java/com/project/global/exception/code/GlobalErrorCode.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum GlobalErrorCode implements BaseErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GLOBAL_001", "서버 내부 오류가 발생했습니다"),
-    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "GLOBAL_002", "입력 값이 올바르지 않습니다.");
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "GLOBAL_002", "입력 값이 올바르지 않습니다."),
+    UNAUTHORIZED_TOKEN(HttpStatus.UNAUTHORIZED, "GLOBAL_003", "인증 토큰이 유효하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String customCode;

--- a/src/test/java/com/project/domain/family/controller/AdminFamilyControllerTest.java
+++ b/src/test/java/com/project/domain/family/controller/AdminFamilyControllerTest.java
@@ -159,7 +159,7 @@ class AdminFamilyControllerTest {
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("FAMILY_002"));
+                .andExpect(jsonPath("$.error.code").value("FAMILY_002"));
     }
 
     @Test
@@ -173,7 +173,7 @@ class AdminFamilyControllerTest {
                         get("/admin/families/{familyId}", 999_999L)
                                 .header("Authorization", "Bearer " + ADMIN_TOKEN))
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value("FAMILY_001"));
+                .andExpect(jsonPath("$.error.code").value("FAMILY_001"));
     }
 
     @Test
@@ -189,6 +189,6 @@ class AdminFamilyControllerTest {
                         get("/admin/families/{familyId}", familyContext.family().getId())
                                 .header("Authorization", "Bearer " + MEMBER_TOKEN))
                 .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.code").value("ADMIN_003"));
+                .andExpect(jsonPath("$.error.code").value("ADMIN_003"));
     }
 }

--- a/src/test/java/com/project/domain/family/controller/FamilyControllerTest.java
+++ b/src/test/java/com/project/domain/family/controller/FamilyControllerTest.java
@@ -119,7 +119,7 @@ class FamilyControllerTest {
                                                 new com.project.domain.family.dto.request
                                                         .FamilyNameUpdateRequest("김씨 가족"))))
                 .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.code").value("CUSTOMER_005"));
+                .andExpect(jsonPath("$.error.code").value("CUSTOMER_005"));
     }
 
     @Test
@@ -196,7 +196,7 @@ class FamilyControllerTest {
     void getCurrentFamilyUsage_noToken_returnsUnauthorized() throws Exception {
         mockMvc.perform(get("/families/usage/current"))
                 .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.code").value("GLOBAL_003"));
+                .andExpect(jsonPath("$.error.code").value("GLOBAL_003"));
     }
 
     @Test
@@ -210,7 +210,7 @@ class FamilyControllerTest {
                                                 new com.project.domain.family.dto.request
                                                         .FamilyNameUpdateRequest("김씨 가족"))))
                 .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.code").value("GLOBAL_003"));
+                .andExpect(jsonPath("$.error.code").value("GLOBAL_003"));
     }
 
     @Test

--- a/src/test/java/com/project/domain/family/controller/FamilyControllerTest.java
+++ b/src/test/java/com/project/domain/family/controller/FamilyControllerTest.java
@@ -174,6 +174,28 @@ class FamilyControllerTest {
     }
 
     @Test
+    @DisplayName("GET /families/usage/current - 토큰 없이 요청하면 401을 반환한다")
+    void getCurrentFamilyUsage_noToken_returnsUnauthorized() throws Exception {
+        mockMvc.perform(get("/families/usage/current"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("GLOBAL_003"));
+    }
+
+    @Test
+    @DisplayName("PUT /families - 토큰 없이 요청하면 401을 반환한다")
+    void updateFamilyName_noToken_returnsUnauthorized() throws Exception {
+        mockMvc.perform(
+                        put("/families")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        objectMapper.writeValueAsString(
+                                                new com.project.domain.family.dto.request
+                                                        .FamilyNameUpdateRequest("김씨 가족"))))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("GLOBAL_003"));
+    }
+
+    @Test
     @DisplayName("GET /families/usage/dashboard returns dashboard usage response")
     void getCustomersUsageDashboardReturnsOk() throws Exception {
         CustomerUsage me = new CustomerUsage(101L, "다봄1", 12_000L, 50_000L, false, null, true);

--- a/src/test/java/com/project/domain/family/controller/FamilyControllerTest.java
+++ b/src/test/java/com/project/domain/family/controller/FamilyControllerTest.java
@@ -1,7 +1,8 @@
 package com.project.domain.family.controller;
 
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -10,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.time.LocalDate;
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +35,10 @@ import com.project.domain.usagerecord.service.UsageRecordService;
 import com.project.global.auth.JwtTokenUtil;
 import com.project.global.auth.aop.OwnerOnlyAspect;
 import com.project.global.config.WebConfig;
+import com.project.global.exception.ApplicationException;
+import com.project.global.exception.code.GlobalErrorCode;
+
+import io.jsonwebtoken.Claims;
 
 @WebMvcTest(FamilyController.class)
 @Import({WebConfig.class, OwnerOnlyAspect.class, FamilyControllerTest.AopTestConfig.class})
@@ -56,6 +62,19 @@ class FamilyControllerTest {
     @MockitoBean private UsageRecordService usageRecordService;
     @MockitoBean private JwtTokenUtil jwtTokenUtil;
 
+    @BeforeEach
+    void setUp() {
+        given(jwtTokenUtil.getVerifiedClaims(null))
+                .willThrow(new ApplicationException(GlobalErrorCode.UNAUTHORIZED_TOKEN));
+    }
+
+    private Claims mockClaims(Long memberId, RoleType role) {
+        Claims claims = mock(Claims.class);
+        doReturn(memberId.toString()).when(claims).getSubject();
+        doReturn(role.name()).when(claims).get("role", String.class);
+        return claims;
+    }
+
     @Test
     @DisplayName("PUT /families - OWNER 권한으로 가족 이름을 수정하면 200을 반환한다")
     void updateFamilyName_ownerRole_returnsOk() throws Exception {
@@ -68,9 +87,8 @@ class FamilyControllerTest {
                         .currentMonth(LocalDate.now().withDayOfMonth(1))
                         .build();
 
-        given(jwtTokenUtil.verify(anyString())).willReturn(null);
-        given(jwtTokenUtil.getMemberId(OWNER_TOKEN)).willReturn(OWNER_ID);
-        given(jwtTokenUtil.getRole(OWNER_TOKEN)).willReturn(RoleType.OWNER);
+        Claims ownerClaims = mockClaims(OWNER_ID, RoleType.OWNER);
+        given(jwtTokenUtil.getVerifiedClaims(OWNER_TOKEN)).willReturn(ownerClaims);
         given(familyService.updateFamilyName(OWNER_ID, "김씨 가족")).willReturn(family);
 
         mockMvc.perform(
@@ -89,8 +107,8 @@ class FamilyControllerTest {
     @Test
     @DisplayName("PUT /families - MEMBER 권한이면 403을 반환한다")
     void updateFamilyName_memberRole_returnsForbidden() throws Exception {
-        given(jwtTokenUtil.verify(anyString())).willReturn(null);
-        given(jwtTokenUtil.getRole(MEMBER_TOKEN)).willReturn(RoleType.MEMBER);
+        Claims memberClaims = mockClaims(MEMBER_ID, RoleType.MEMBER);
+        given(jwtTokenUtil.getVerifiedClaims(MEMBER_TOKEN)).willReturn(memberClaims);
 
         mockMvc.perform(
                         put("/families")
@@ -107,8 +125,8 @@ class FamilyControllerTest {
     @Test
     @DisplayName("PUT /families - 이름이 빈 값이면 400을 반환한다")
     void updateFamilyName_blankName_returnsBadRequest() throws Exception {
-        given(jwtTokenUtil.verify(anyString())).willReturn(null);
-        given(jwtTokenUtil.getRole(OWNER_TOKEN)).willReturn(RoleType.OWNER);
+        Claims ownerClaims = mockClaims(OWNER_ID, RoleType.OWNER);
+        given(jwtTokenUtil.getVerifiedClaims(OWNER_TOKEN)).willReturn(ownerClaims);
 
         mockMvc.perform(
                         put("/families")
@@ -123,8 +141,8 @@ class FamilyControllerTest {
     void getCurrentFamilyUsageReturnsOk() throws Exception {
         FamilyUsage familyUsage = new FamilyUsage(1L, "테스트 가족", 100_000L, 40_000L);
 
-        given(jwtTokenUtil.verify(anyString())).willReturn(null);
-        given(jwtTokenUtil.getMemberId(MEMBER_TOKEN)).willReturn(MEMBER_ID);
+        Claims memberClaims = mockClaims(MEMBER_ID, RoleType.MEMBER);
+        given(jwtTokenUtil.getVerifiedClaims(MEMBER_TOKEN)).willReturn(memberClaims);
         given(usageRecordService.getCurrentFamilyUsage(MEMBER_ID)).willReturn(familyUsage);
 
         mockMvc.perform(
@@ -147,8 +165,8 @@ class FamilyControllerTest {
         FamilyCustomersUsageSummary usageSummary =
                 new FamilyCustomersUsageSummary(1L, 2026, 2, List.of(me, other));
 
-        given(jwtTokenUtil.verify(anyString())).willReturn(null);
-        given(jwtTokenUtil.getMemberId(MEMBER_TOKEN)).willReturn(MEMBER_ID);
+        Claims memberClaims = mockClaims(MEMBER_ID, RoleType.MEMBER);
+        given(jwtTokenUtil.getVerifiedClaims(MEMBER_TOKEN)).willReturn(memberClaims);
         given(usageRecordService.getCustomersUsageSummaryReport(MEMBER_ID, 2026, 2))
                 .willReturn(usageSummary);
 
@@ -205,8 +223,8 @@ class FamilyControllerTest {
                 new FamilyCustomersUsage(
                         1L, "다봄가족", 2026, 2, 100_000L, 58_000L, 42.0, List.of(me, other));
 
-        given(jwtTokenUtil.verify(anyString())).willReturn(null);
-        given(jwtTokenUtil.getMemberId(MEMBER_TOKEN)).willReturn(MEMBER_ID);
+        Claims memberClaims = mockClaims(MEMBER_ID, RoleType.MEMBER);
+        given(jwtTokenUtil.getVerifiedClaims(MEMBER_TOKEN)).willReturn(memberClaims);
         given(usageRecordService.getCustomersUsageReport(MEMBER_ID, 2026, 2))
                 .willReturn(usageReport);
 

--- a/src/test/java/com/project/domain/mission/controller/MissionControllerIntegrationTest.java
+++ b/src/test/java/com/project/domain/mission/controller/MissionControllerIntegrationTest.java
@@ -1,7 +1,9 @@
 package com.project.domain.mission.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -51,6 +53,8 @@ import com.project.domain.reward.enums.RewardCategory;
 import com.project.domain.reward.repository.RewardRepository;
 import com.project.domain.reward.repository.RewardTemplateRepository;
 import com.project.global.auth.JwtTokenUtil;
+
+import io.jsonwebtoken.Claims;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -143,13 +147,16 @@ class MissionControllerIntegrationTest {
                                 .status(MissionStatus.ACTIVE)
                                 .build());
 
-        lenient()
-                .when(jwtTokenUtil.verify(org.mockito.ArgumentMatchers.anyString()))
-                .thenReturn(null);
-        lenient().when(jwtTokenUtil.getMemberId(OWNER_TOKEN)).thenReturn(owner.getId());
-        lenient().when(jwtTokenUtil.getMemberId(MEMBER_TOKEN)).thenReturn(member.getId());
-        lenient().when(jwtTokenUtil.getRole(OWNER_TOKEN)).thenReturn(RoleType.OWNER);
-        lenient().when(jwtTokenUtil.getRole(MEMBER_TOKEN)).thenReturn(RoleType.MEMBER);
+        Claims ownerClaims = mock(Claims.class);
+        doReturn(owner.getId().toString()).when(ownerClaims).getSubject();
+        doReturn(RoleType.OWNER.name()).when(ownerClaims).get("role", String.class);
+
+        Claims memberClaims = mock(Claims.class);
+        doReturn(member.getId().toString()).when(memberClaims).getSubject();
+        doReturn(RoleType.MEMBER.name()).when(memberClaims).get("role", String.class);
+
+        lenient().when(jwtTokenUtil.getVerifiedClaims(OWNER_TOKEN)).thenReturn(ownerClaims);
+        lenient().when(jwtTokenUtil.getVerifiedClaims(MEMBER_TOKEN)).thenReturn(memberClaims);
     }
 
     @Test

--- a/src/test/java/com/project/domain/recap/controller/RecapControllerTest.java
+++ b/src/test/java/com/project/domain/recap/controller/RecapControllerTest.java
@@ -1,7 +1,8 @@
 package com.project.domain.recap.controller;
 
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -26,6 +27,8 @@ import com.project.global.config.WebConfig;
 import com.project.global.exception.ApplicationException;
 import com.project.global.exception.ExceptionAdvice;
 import com.project.global.exception.code.RecapErrorCode;
+
+import io.jsonwebtoken.Claims;
 
 @WebMvcTest(RecapController.class)
 @Import({WebConfig.class, ExceptionAdvice.class})
@@ -81,8 +84,9 @@ class RecapControllerTest {
                         new BigDecimal("82.5"),
                         LocalDateTime.of(2026, 3, 1, 0, 0));
 
-        given(jwtTokenUtil.verify(anyString())).willReturn(null);
-        given(jwtTokenUtil.getMemberId(MEMBER_TOKEN)).willReturn(MEMBER_ID);
+        Claims memberClaims = mock(Claims.class);
+        doReturn(MEMBER_ID.toString()).when(memberClaims).getSubject();
+        given(jwtTokenUtil.getVerifiedClaims(MEMBER_TOKEN)).willReturn(memberClaims);
         given(recapService.getMonthlyRecap(MEMBER_ID, 2026, 3)).willReturn(monthlyRecap);
 
         mockMvc.perform(
@@ -115,8 +119,9 @@ class RecapControllerTest {
     @Test
     @DisplayName("GET /recaps/monthly - 리캡이 없으면 404를 반환한다")
     void getMonthlyRecap_notFound_returnsNotFound() throws Exception {
-        given(jwtTokenUtil.verify(anyString())).willReturn(null);
-        given(jwtTokenUtil.getMemberId(MEMBER_TOKEN)).willReturn(MEMBER_ID);
+        Claims memberClaims = mock(Claims.class);
+        doReturn(MEMBER_ID.toString()).when(memberClaims).getSubject();
+        given(jwtTokenUtil.getVerifiedClaims(MEMBER_TOKEN)).willReturn(memberClaims);
         given(recapService.getMonthlyRecap(MEMBER_ID, 2026, 3))
                 .willThrow(new ApplicationException(RecapErrorCode.RECAP_NOT_FOUND));
 

--- a/src/test/java/com/project/domain/recap/controller/RecapControllerTest.java
+++ b/src/test/java/com/project/domain/recap/controller/RecapControllerTest.java
@@ -131,6 +131,6 @@ class RecapControllerTest {
                                 .param("month", "3")
                                 .header("Authorization", "Bearer " + MEMBER_TOKEN))
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value("RECAP_001"));
+                .andExpect(jsonPath("$.error.code").value("RECAP_001"));
     }
 }

--- a/src/test/java/com/project/domain/reward/controller/RewardControllerIntegrationTest.java
+++ b/src/test/java/com/project/domain/reward/controller/RewardControllerIntegrationTest.java
@@ -1,7 +1,9 @@
 package com.project.domain.reward.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -48,6 +50,8 @@ import com.project.domain.reward.enums.RewardCategory;
 import com.project.domain.reward.repository.RewardRepository;
 import com.project.domain.reward.repository.RewardTemplateRepository;
 import com.project.global.auth.JwtTokenUtil;
+
+import io.jsonwebtoken.Claims;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -139,13 +143,16 @@ class RewardControllerIntegrationTest {
                                 .status(MissionStatus.ACTIVE)
                                 .build());
 
-        lenient()
-                .when(jwtTokenUtil.verify(org.mockito.ArgumentMatchers.anyString()))
-                .thenReturn(null);
-        lenient().when(jwtTokenUtil.getMemberId(OWNER_TOKEN)).thenReturn(owner.getId());
-        lenient().when(jwtTokenUtil.getMemberId(MEMBER_TOKEN)).thenReturn(member.getId());
-        lenient().when(jwtTokenUtil.getRole(OWNER_TOKEN)).thenReturn(RoleType.OWNER);
-        lenient().when(jwtTokenUtil.getRole(MEMBER_TOKEN)).thenReturn(RoleType.MEMBER);
+        Claims ownerClaims = mock(Claims.class);
+        doReturn(owner.getId().toString()).when(ownerClaims).getSubject();
+        doReturn(RoleType.OWNER.name()).when(ownerClaims).get("role", String.class);
+
+        Claims memberClaims = mock(Claims.class);
+        doReturn(member.getId().toString()).when(memberClaims).getSubject();
+        doReturn(RoleType.MEMBER.name()).when(memberClaims).get("role", String.class);
+
+        lenient().when(jwtTokenUtil.getVerifiedClaims(OWNER_TOKEN)).thenReturn(ownerClaims);
+        lenient().when(jwtTokenUtil.getVerifiedClaims(MEMBER_TOKEN)).thenReturn(memberClaims);
     }
 
     @Test


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

- closed: #100 
- jira: DABOM-432

---

## 🎯 목적

토큰이 필요한 엔드포인트에 Authorization 헤더 없이 접근하면 500 Internal Server Error가 반환되는 문제를 수정합니다. 인증 체계(Interceptor + AOP + ArgumentResolver) 전반에서 null 토큰 처리가 누락되어 있고, 글로벌 예외 핸들러에도 `@ExceptionHandler` 어노테이션이 빠져있어 `JwtException`이 처리되지 않던 것이 근본 원인입니다.

## 📝 변경 사항

- `GlobalErrorCode`에 `UNAUTHORIZED_TOKEN`(401, GLOBAL_003) 에러 코드 추가
- `LoginInterceptor`에 null/blank 토큰 체크 및 try-catch 추가
- `OwnerOnlyAspect`에 `AdminOnlyAspect`와 동일한 방어 패턴 적용
- `CustomerArgumentResolver`에 방어적 null 토큰 체크 및 try-catch 추가
- `ExceptionAdvice.handleUnhandledException()`에 누락된 `@ExceptionHandler(Exception.class)` 어노테이션 추가
- `FamilyControllerTest`에 토큰 미전송 시 401 반환 테스트 2건 추가

## 📂 변경 범위

| 도메인 | controller | service | repository | entity | infra | global |
| :----: | :--------: | :-----: | :--------: | :----: | :---: | :----: |
| family |            |         |            |        |       | [x]    |

---

## 🖥️ 주요 코드 설명

```java
// LoginInterceptor — 기존: null 토큰이 JwtTokenUtil로 전달되어 JwtException → 500
// 변경: null 체크 후 ApplicationException(401) 반환
final String token = AuthorizationExtractor.extract(request);
if (token == null || token.isBlank()) {
    throw new ApplicationException(GlobalErrorCode.UNAUTHORIZED_TOKEN);
}
try {
    jwtTokenUtil.verifyAccessToken(token);
} catch (RuntimeException e) {
    throw new ApplicationException(GlobalErrorCode.UNAUTHORIZED_TOKEN);
}
```

```java
// ExceptionAdvice — 기존: @ExceptionHandler 누락으로 메서드 호출 안 됨
// 변경: 어노테이션 추가하여 안전망 역할
@ExceptionHandler(Exception.class)
public ResponseEntity<Object> handleUnhandledException(Exception e, WebRequest request) {
```

## 💬 리뷰어에게

- `AdminOnlyAspect`는 이미 null 체크 + try-catch가 구현되어 있었고, 나머지 인증 레이어(`LoginInterceptor`, `OwnerOnlyAspect`, `CustomerArgumentResolver`)에 동일 패턴을 적용했습니다.
- `ExceptionAdvice`의 `@ExceptionHandler(Exception.class)` 추가는 향후 예상치 못한 예외에 대한 안전망입니다. 정상 경로에서는 각 인증 레이어가 `ApplicationException`을 던지므로 `handleBaseException()`에서 처리됩니다.

---

## 📋 체크리스트

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [x] 전체 변경사항이 500줄을 넘지 않는가?

**코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → Repository → Entity`)
- [x] Setter 없이 비즈니스 메서드로 상태를 변경하는가?
- [x] `@Transactional`은 Service에만 선언했는가?

**테스트**
- [x] 신규 비즈니스 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항
- 토큰 미전송 테스트 2건: `GET /families/usage/current`, `PUT /families` (@OwnerOnly)
