### PR TITLE
[DABOM-435] GET /admin/rewards/templates/{id}

### DIFF
--- a/src/main/java/com/project/domain/reward/controller/AdminRewardTemplateController.java
+++ b/src/main/java/com/project/domain/reward/controller/AdminRewardTemplateController.java
@@ -50,8 +50,8 @@ public class AdminRewardTemplateController {
     @GetMapping("/{id}")
     @AdminOnly
     @Operation(summary = "보상 템플릿 상세 조회", description = "보상 템플릿 ID로 상세 정보를 조회합니다.")
-    @Parameter(name = "id", description = "보상 템플릿 ID", required = true)
-    public ApiResponse<RewardTemplateResponse.Detail> getTemplate(@PathVariable Long id) {
+    public ApiResponse<RewardTemplateResponse.Detail> getTemplate(
+            @Parameter(description = "보상 템플릿 ID", required = true) @PathVariable("id") Long id) {
         RewardTemplate template = rewardTemplateService.getTemplate(id);
         return ApiResponse.success(RewardTemplateResponse.Detail.from(template));
     }
@@ -69,9 +69,9 @@ public class AdminRewardTemplateController {
     @PutMapping("/{id}")
     @AdminOnly
     @Operation(summary = "보상 템플릿 수정", description = "보상 템플릿을 수정합니다.")
-    @Parameter(name = "id", description = "보상 템플릿 ID", required = true)
     public ApiResponse<RewardTemplateResponse.Detail> updateTemplate(
-            @PathVariable Long id, @Valid @RequestBody RewardTemplateRequest.Update request) {
+            @Parameter(description = "보상 템플릿 ID", required = true) @PathVariable("id") Long id,
+            @Valid @RequestBody RewardTemplateRequest.Update request) {
         RewardTemplate template = rewardTemplateService.updateTemplate(id, request);
         return ApiResponse.success(RewardTemplateResponse.Detail.from(template));
     }
@@ -80,8 +80,8 @@ public class AdminRewardTemplateController {
     @AdminOnly
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @Operation(summary = "보상 템플릿 삭제", description = "보상 템플릿을 삭제합니다. (Soft Delete)")
-    @Parameter(name = "id", description = "보상 템플릿 ID", required = true)
-    public ApiResponse<Void> deleteTemplate(@PathVariable Long id) {
+    public ApiResponse<Void> deleteTemplate(
+            @Parameter(description = "보상 템플릿 ID", required = true) @PathVariable("id") Long id) {
         rewardTemplateService.deleteTemplate(id);
         return ApiResponse.success(null);
     }

--- a/src/main/java/com/project/domain/reward/controller/AdminRewardTemplateController.java
+++ b/src/main/java/com/project/domain/reward/controller/AdminRewardTemplateController.java
@@ -47,6 +47,15 @@ public class AdminRewardTemplateController {
         return ApiResponse.success(result);
     }
 
+    @GetMapping("/{id}")
+    @AdminOnly
+    @Operation(summary = "보상 템플릿 상세 조회", description = "보상 템플릿 ID로 상세 정보를 조회합니다.")
+    @Parameter(name = "id", description = "보상 템플릿 ID", required = true)
+    public ApiResponse<RewardTemplateResponse.Detail> getTemplate(@PathVariable Long id) {
+        RewardTemplate template = rewardTemplateService.getTemplate(id);
+        return ApiResponse.success(RewardTemplateResponse.Detail.from(template));
+    }
+
     @PostMapping
     @AdminOnly
     @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/java/com/project/domain/reward/service/RewardTemplateService.java
+++ b/src/main/java/com/project/domain/reward/service/RewardTemplateService.java
@@ -9,6 +9,8 @@ public interface RewardTemplateService {
 
     List<RewardTemplate> getAllTemplates();
 
+    RewardTemplate getTemplate(Long id);
+
     RewardTemplate createTemplate(RewardTemplateRequest.Create request);
 
     RewardTemplate updateTemplate(Long id, RewardTemplateRequest.Update request);

--- a/src/main/java/com/project/domain/reward/service/RewardTemplateServiceImpl.java
+++ b/src/main/java/com/project/domain/reward/service/RewardTemplateServiceImpl.java
@@ -26,6 +26,11 @@ public class RewardTemplateServiceImpl implements RewardTemplateService {
     }
 
     @Override
+    public RewardTemplate getTemplate(Long id) {
+        return findTemplateOrThrow(id);
+    }
+
+    @Override
     @Transactional
     public RewardTemplate createTemplate(RewardTemplateRequest.Create request) {
         RewardTemplate template =

--- a/src/test/java/com/project/domain/reward/service/RewardTemplateServiceImplTest.java
+++ b/src/test/java/com/project/domain/reward/service/RewardTemplateServiceImplTest.java
@@ -55,6 +55,48 @@ class RewardTemplateServiceImplTest {
     }
 
     @Test
+    @DisplayName("getTemplate - ID로 템플릿을 조회한다")
+    void getTemplate_validId_returnsTemplate() {
+        // given
+        Long id = 1L;
+        RewardTemplate template =
+                RewardTemplate.builder()
+                        .name("메가커피 아메리카노")
+                        .category(RewardCategory.GIFTICON)
+                        .price(3000)
+                        .isSystem(true)
+                        .isActive(true)
+                        .build();
+        given(rewardTemplateRepository.findByIdAndDeletedAtIsNull(id))
+                .willReturn(Optional.of(template));
+
+        // when
+        RewardTemplate result = rewardTemplateService.getTemplate(id);
+
+        // then
+        assertThat(result.getName()).isEqualTo("메가커피 아메리카노");
+        assertThat(result.getCategory()).isEqualTo(RewardCategory.GIFTICON);
+        assertThat(result.getPrice()).isEqualTo(3000);
+        verify(rewardTemplateRepository).findByIdAndDeletedAtIsNull(id);
+    }
+
+    @Test
+    @DisplayName("getTemplate - 존재하지 않는 ID 조회 시 예외가 발생한다")
+    void getTemplate_notFoundId_throwsException() {
+        // given
+        Long id = 999L;
+        given(rewardTemplateRepository.findByIdAndDeletedAtIsNull(id)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> rewardTemplateService.getTemplate(id))
+                .isInstanceOf(ApplicationException.class)
+                .satisfies(
+                        e ->
+                                assertThat(((ApplicationException) e).getCode())
+                                        .isEqualTo(RewardErrorCode.REWARD_TEMPLATE_NOT_FOUND));
+    }
+
+    @Test
     @DisplayName("createTemplate - 새로운 템플릿을 생성하고 저장한다")
     void createTemplate_validRequest_savesAndReturnsTemplate() {
         // given


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

- closed: #101 
- jira: DABOM-435

---

## 🎯 목적

API 스펙에 정의된 보상 템플릿 상세 조회 엔드포인트(`GET /admin/rewards/templates/{id}`)가 누락되어 있어 구현합니다. 기존 CRUD 중 목록 조회·생성·수정·삭제는 모두 존재하나, 단건 상세 조회만 빠져있던 상태입니다.

## 📝 변경 사항

- `RewardTemplateService` 인터페이스에 `getTemplate(Long id)` 메서드 추가
- `RewardTemplateServiceImpl`에 `getTemplate` 구현 (기존 `findTemplateOrThrow` 재사용)
- `AdminRewardTemplateController`에 `GET /{id}` 엔드포인트 추가

## 📂 변경 범위

| 도메인 | controller | service | repository | entity | infra | global |
| :----: | :--------: | :-----: | :--------: | :----: | :---: | :----: |
| reward |    [x]     |   [x]   |            |        |       |        |

---

## 🖥️ 주요 코드 설명

```java
// AdminRewardTemplateController — 기존 PUT/DELETE 패턴과 동일한 구조
@GetMapping("/{id}")
@AdminOnly
@Operation(summary = "보상 템플릿 상세 조회", description = "보상 템플릿 ID로 상세 정보를 조회합니다.")
@Parameter(name = "id", description = "보상 템플릿 ID", required = true)
public ApiResponse<RewardTemplateResponse.Detail> getTemplate(@PathVariable Long id) {
    RewardTemplate template = rewardTemplateService.getTemplate(id);
    return ApiResponse.success(RewardTemplateResponse.Detail.from(template));
}
```

## 💬 리뷰어에게

- Repository(`findByIdAndDeletedAtIsNull`), DTO(`RewardTemplateResponse.Detail`), 에러 코드(`REWARD_TEMPLATE_NOT_FOUND`) 모두 기존에 존재하여 신규 생성 없이 재사용했습니다.
- `getTemplate`은 조회 전용이므로 클래스 레벨 `@Transactional(readOnly = true)`를 상속받습니다.

---

## 📋 체크리스트

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [x] 전체 변경사항이 500줄을 넘지 않는가?

**코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → Repository → Entity`)
- [x] Setter 없이 비즈니스 메서드로 상태를 변경하는가?
- [x] `@Transactional`은 Service에만 선언했는가?

**테스트**
- [x] 신규 비즈니스 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

- `getTemplate` 정상 조회 및 존재하지 않는 ID 예외 케이스 테스트 2건 추가
