### PR TITLE
[DABOM-416] R2(S3 like) image 업로드 기능 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,13 @@ KAFKA_AUTO_OFFSET_RESET=earliest
 KAFKA_POLICY_DEDUP_TTL_SECONDS=3600
 KAFKA_USAGE_PERSIST_DEDUP_TTL_SECONDS=600
 
+# --- R2 (Cloudflare S3 compatible) ---
+R2_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com
+R2_ACCESS_KEY=changeme
+R2_SECRET_KEY=changeme
+R2_BUCKET=dabom-storage
+R2_CDN_BASE_URL=https://cdn.dabom.site
+
 # --- CORS ---
 FRONTEND_URL=http://localhost:3000,http://localhost:3001
 

--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,10 @@ dependencies {
     //BCrypt
     implementation 'org.mindrot:jbcrypt:0.4'
 
+    // AWS SDK v2 - S3 (R2 compatible)
+    implementation platform('software.amazon.awssdk:bom:2.25.70')
+    implementation 'software.amazon.awssdk:s3'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/project/domain/upload/controller/UploadController.java
+++ b/src/main/java/com/project/domain/upload/controller/UploadController.java
@@ -1,0 +1,41 @@
+package com.project.domain.upload.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.project.domain.upload.dto.response.UploadResponse;
+import com.project.domain.upload.enums.UploadType;
+import com.project.domain.upload.service.UploadService;
+import com.project.global.api.response.ApiResponse;
+import com.project.global.auth.aop.AdminOnly;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/uploads")
+@RequiredArgsConstructor
+@Tag(name = "Upload", description = "파일 업로드 API")
+public class UploadController {
+
+    private final UploadService uploadService;
+
+    @PostMapping(value = "/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @AdminOnly
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "이미지 업로드", description = "이미지를 R2에 업로드하고 CDN URL을 반환합니다.")
+    public ApiResponse<UploadResponse> uploadImage(
+            @RequestParam("file") MultipartFile file, @RequestParam("type") UploadType type) {
+
+        UploadResponse response = uploadService.upload(file, type);
+        return ApiResponse.created(response);
+    }
+}

--- a/src/main/java/com/project/domain/upload/controller/UploadController.java
+++ b/src/main/java/com/project/domain/upload/controller/UploadController.java
@@ -35,7 +35,7 @@ public class UploadController {
     public ApiResponse<UploadResponse> uploadImage(
             @RequestParam("file") MultipartFile file, @RequestParam("type") UploadType type) {
 
-        UploadResponse response = uploadService.upload(file, type);
-        return ApiResponse.created(response);
+        String cdnUrl = uploadService.upload(file, type);
+        return ApiResponse.created(UploadResponse.from(cdnUrl));
     }
 }

--- a/src/main/java/com/project/domain/upload/dto/response/UploadResponse.java
+++ b/src/main/java/com/project/domain/upload/dto/response/UploadResponse.java
@@ -1,0 +1,8 @@
+package com.project.domain.upload.dto.response;
+
+public record UploadResponse(String url) {
+
+    public static UploadResponse from(String url) {
+        return new UploadResponse(url);
+    }
+}

--- a/src/main/java/com/project/domain/upload/enums/UploadType.java
+++ b/src/main/java/com/project/domain/upload/enums/UploadType.java
@@ -1,0 +1,14 @@
+package com.project.domain.upload.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UploadType {
+    REWARD("rewards"),
+    PROFILE("profiles"),
+    MISSION("missions");
+
+    private final String prefix;
+}

--- a/src/main/java/com/project/domain/upload/service/UploadService.java
+++ b/src/main/java/com/project/domain/upload/service/UploadService.java
@@ -2,10 +2,9 @@ package com.project.domain.upload.service;
 
 import org.springframework.web.multipart.MultipartFile;
 
-import com.project.domain.upload.dto.response.UploadResponse;
 import com.project.domain.upload.enums.UploadType;
 
 public interface UploadService {
 
-    UploadResponse upload(MultipartFile file, UploadType type);
+    String upload(MultipartFile file, UploadType type);
 }

--- a/src/main/java/com/project/domain/upload/service/UploadService.java
+++ b/src/main/java/com/project/domain/upload/service/UploadService.java
@@ -1,0 +1,11 @@
+package com.project.domain.upload.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import com.project.domain.upload.dto.response.UploadResponse;
+import com.project.domain.upload.enums.UploadType;
+
+public interface UploadService {
+
+    UploadResponse upload(MultipartFile file, UploadType type);
+}

--- a/src/main/java/com/project/domain/upload/service/UploadServiceImpl.java
+++ b/src/main/java/com/project/domain/upload/service/UploadServiceImpl.java
@@ -1,5 +1,6 @@
 package com.project.domain.upload.service;
 
+import java.io.IOException;
 import java.util.Set;
 import java.util.UUID;
 
@@ -11,6 +12,7 @@ import com.project.domain.upload.enums.UploadType;
 import com.project.global.exception.ApplicationException;
 import com.project.global.exception.code.UploadErrorCode;
 
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -37,7 +39,7 @@ public class UploadServiceImpl implements UploadService {
     public String upload(MultipartFile file, UploadType type) {
         validateFile(file);
 
-        String extension = extractExtension(file.getOriginalFilename());
+        String extension = extractExtension(file.getContentType());
         String fileName = UUID.randomUUID() + "." + extension;
         String key = type.getPrefix() + "/" + fileName;
 
@@ -51,7 +53,7 @@ public class UploadServiceImpl implements UploadService {
 
             s3Client.putObject(
                     putRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
-        } catch (Exception e) {
+        } catch (IOException | SdkException e) {
             throw new ApplicationException(UploadErrorCode.UPLOAD_FAILED);
         }
 
@@ -71,10 +73,10 @@ public class UploadServiceImpl implements UploadService {
         }
     }
 
-    private String extractExtension(String originalFilename) {
-        if (originalFilename == null || !originalFilename.contains(".")) {
-            return "png";
-        }
-        return originalFilename.substring(originalFilename.lastIndexOf('.') + 1).toLowerCase();
+    private String extractExtension(String contentType) {
+        if ("image/png".equals(contentType)) return "png";
+        if ("image/jpeg".equals(contentType)) return "jpg";
+        if ("image/webp".equals(contentType)) return "webp";
+        throw new ApplicationException(UploadErrorCode.INVALID_MIME_TYPE);
     }
 }

--- a/src/main/java/com/project/domain/upload/service/UploadServiceImpl.java
+++ b/src/main/java/com/project/domain/upload/service/UploadServiceImpl.java
@@ -74,9 +74,15 @@ public class UploadServiceImpl implements UploadService {
     }
 
     private String extractExtension(String contentType) {
-        if ("image/png".equals(contentType)) return "png";
-        if ("image/jpeg".equals(contentType)) return "jpg";
-        if ("image/webp".equals(contentType)) return "webp";
+        if ("image/png".equals(contentType)) {
+            return "png";
+        }
+        if ("image/jpeg".equals(contentType)) {
+            return "jpg";
+        }
+        if ("image/webp".equals(contentType)) {
+            return "webp";
+        }
         throw new ApplicationException(UploadErrorCode.INVALID_MIME_TYPE);
     }
 }

--- a/src/main/java/com/project/domain/upload/service/UploadServiceImpl.java
+++ b/src/main/java/com/project/domain/upload/service/UploadServiceImpl.java
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.project.domain.upload.dto.response.UploadResponse;
 import com.project.domain.upload.enums.UploadType;
 import com.project.global.exception.ApplicationException;
 import com.project.global.exception.code.UploadErrorCode;
@@ -35,7 +34,7 @@ public class UploadServiceImpl implements UploadService {
     private String cdnBaseUrl;
 
     @Override
-    public UploadResponse upload(MultipartFile file, UploadType type) {
+    public String upload(MultipartFile file, UploadType type) {
         validateFile(file);
 
         String extension = extractExtension(file.getOriginalFilename());
@@ -56,8 +55,7 @@ public class UploadServiceImpl implements UploadService {
             throw new ApplicationException(UploadErrorCode.UPLOAD_FAILED);
         }
 
-        String cdnUrl = cdnBaseUrl + "/" + key;
-        return UploadResponse.from(cdnUrl);
+        return cdnBaseUrl + "/" + key;
     }
 
     private void validateFile(MultipartFile file) {

--- a/src/main/java/com/project/domain/upload/service/UploadServiceImpl.java
+++ b/src/main/java/com/project/domain/upload/service/UploadServiceImpl.java
@@ -1,0 +1,85 @@
+package com.project.domain.upload.service;
+
+import java.util.Set;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.project.domain.upload.dto.response.UploadResponse;
+import com.project.domain.upload.enums.UploadType;
+import com.project.global.exception.ApplicationException;
+import com.project.global.exception.code.UploadErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Service
+@RequiredArgsConstructor
+public class UploadServiceImpl implements UploadService {
+
+    private static final Set<String> ALLOWED_MIME_TYPES =
+            Set.of("image/png", "image/jpeg", "image/webp");
+    private static final long MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
+    private final S3Client s3Client;
+
+    @Value("${r2.bucket}")
+    private String bucket;
+
+    @Value("${r2.cdn-base-url}")
+    private String cdnBaseUrl;
+
+    @Override
+    public UploadResponse upload(MultipartFile file, UploadType type) {
+        validateFile(file);
+
+        String extension = extractExtension(file.getOriginalFilename());
+        String fileName = UUID.randomUUID() + "." + extension;
+        String key = type.getPrefix() + "/" + fileName;
+
+        try {
+            PutObjectRequest putRequest =
+                    PutObjectRequest.builder()
+                            .bucket(bucket)
+                            .key(key)
+                            .contentType(file.getContentType())
+                            .build();
+
+            s3Client.putObject(
+                    putRequest,
+                    RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+        } catch (Exception e) {
+            throw new ApplicationException(UploadErrorCode.UPLOAD_FAILED);
+        }
+
+        String cdnUrl = cdnBaseUrl + "/" + key;
+        return UploadResponse.from(cdnUrl);
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new ApplicationException(UploadErrorCode.FILE_REQUIRED);
+        }
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new ApplicationException(UploadErrorCode.FILE_TOO_LARGE);
+        }
+        String contentType = file.getContentType();
+        if (contentType == null || !ALLOWED_MIME_TYPES.contains(contentType)) {
+            throw new ApplicationException(UploadErrorCode.INVALID_MIME_TYPE);
+        }
+    }
+
+    private String extractExtension(String originalFilename) {
+        if (originalFilename == null || !originalFilename.contains(".")) {
+            return "png";
+        }
+        return originalFilename
+                .substring(originalFilename.lastIndexOf('.') + 1)
+                .toLowerCase();
+    }
+}

--- a/src/main/java/com/project/domain/upload/service/UploadServiceImpl.java
+++ b/src/main/java/com/project/domain/upload/service/UploadServiceImpl.java
@@ -12,11 +12,11 @@ import com.project.domain.upload.enums.UploadType;
 import com.project.global.exception.ApplicationException;
 import com.project.global.exception.code.UploadErrorCode;
 
-import lombok.RequiredArgsConstructor;
-
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -51,8 +51,7 @@ public class UploadServiceImpl implements UploadService {
                             .build();
 
             s3Client.putObject(
-                    putRequest,
-                    RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+                    putRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
         } catch (Exception e) {
             throw new ApplicationException(UploadErrorCode.UPLOAD_FAILED);
         }
@@ -78,8 +77,6 @@ public class UploadServiceImpl implements UploadService {
         if (originalFilename == null || !originalFilename.contains(".")) {
             return "png";
         }
-        return originalFilename
-                .substring(originalFilename.lastIndexOf('.') + 1)
-                .toLowerCase();
+        return originalFilename.substring(originalFilename.lastIndexOf('.') + 1).toLowerCase();
     }
 }

--- a/src/main/java/com/project/domain/upload/service/UploadServiceImpl.java
+++ b/src/main/java/com/project/domain/upload/service/UploadServiceImpl.java
@@ -25,7 +25,7 @@ public class UploadServiceImpl implements UploadService {
 
     private static final Set<String> ALLOWED_MIME_TYPES =
             Set.of("image/png", "image/jpeg", "image/webp");
-    private static final long MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+    private static final long MAX_FILE_SIZE = 5L * 1024 * 1024; // 5MB
 
     private final S3Client s3Client;
 

--- a/src/main/java/com/project/global/config/R2Config.java
+++ b/src/main/java/com/project/global/config/R2Config.java
@@ -28,9 +28,7 @@ public class R2Config {
                                 AwsBasicCredentials.create(accessKey, secretKey)))
                 .region(Region.of("auto"))
                 .serviceConfiguration(
-                        S3Configuration.builder()
-                                .pathStyleAccessEnabled(true)
-                                .build())
+                        S3Configuration.builder().pathStyleAccessEnabled(true).build())
                 .build();
     }
 }

--- a/src/main/java/com/project/global/config/R2Config.java
+++ b/src/main/java/com/project/global/config/R2Config.java
@@ -1,0 +1,36 @@
+package com.project.global.config;
+
+import java.net.URI;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+
+@Configuration
+public class R2Config {
+
+    @Bean
+    public S3Client s3Client(
+            @Value("${r2.endpoint}") String endpoint,
+            @Value("${r2.access-key}") String accessKey,
+            @Value("${r2.secret-key}") String secretKey) {
+
+        return S3Client.builder()
+                .endpointOverride(URI.create(endpoint))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(accessKey, secretKey)))
+                .region(Region.of("auto"))
+                .serviceConfiguration(
+                        S3Configuration.builder()
+                                .pathStyleAccessEnabled(true)
+                                .build())
+                .build();
+    }
+}

--- a/src/main/java/com/project/global/exception/code/UploadErrorCode.java
+++ b/src/main/java/com/project/global/exception/code/UploadErrorCode.java
@@ -1,0 +1,19 @@
+package com.project.global.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UploadErrorCode implements BaseErrorCode {
+    FILE_REQUIRED(HttpStatus.BAD_REQUEST, "UPLOAD_001", "파일이 없습니다."),
+    INVALID_MIME_TYPE(HttpStatus.BAD_REQUEST, "UPLOAD_002", "지원하지 않는 파일 타입입니다."),
+    FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "UPLOAD_003", "파일 크기가 5MB를 초과합니다."),
+    UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "UPLOAD_004", "파일 업로드에 실패했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String customCode;
+    private final String message;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,6 +53,18 @@ spring:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
 
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 5MB
+
+r2:
+  endpoint: ${R2_ENDPOINT:https://localhost.r2.cloudflarestorage.com}
+  access-key: ${R2_ACCESS_KEY:changeme}
+  secret-key: ${R2_SECRET_KEY:changeme}
+  bucket: ${R2_BUCKET:dabom-storage}
+  cdn-base-url: ${R2_CDN_BASE_URL:https://cdn.dabom.site}
+
 server:
   port: ${SERVER_PORT:8080}
 

--- a/src/test/java/com/project/domain/upload/service/UploadServiceImplTest.java
+++ b/src/test/java/com/project/domain/upload/service/UploadServiceImplTest.java
@@ -52,8 +52,7 @@ class UploadServiceImplTest {
         String result = uploadService.upload(file, UploadType.REWARD);
 
         // then
-        assertThat(result).startsWith("https://cdn.test.com/rewards/");
-        assertThat(result).endsWith(".png");
+        assertThat(result).startsWith("https://cdn.test.com/rewards/").endsWith(".png");
         verify(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
     }
 
@@ -149,8 +148,7 @@ class UploadServiceImplTest {
         String result = uploadService.upload(file, UploadType.MISSION);
 
         // then
-        assertThat(result).startsWith("https://cdn.test.com/missions/");
-        assertThat(result).endsWith(".webp");
+        assertThat(result).startsWith("https://cdn.test.com/missions/").endsWith(".webp");
     }
 
     @Test
@@ -166,7 +164,6 @@ class UploadServiceImplTest {
         String result = uploadService.upload(file, UploadType.PROFILE);
 
         // then
-        assertThat(result).startsWith("https://cdn.test.com/profiles/");
-        assertThat(result).endsWith(".jpg");
+        assertThat(result).startsWith("https://cdn.test.com/profiles/").endsWith(".jpg");
     }
 }

--- a/src/test/java/com/project/domain/upload/service/UploadServiceImplTest.java
+++ b/src/test/java/com/project/domain/upload/service/UploadServiceImplTest.java
@@ -152,4 +152,21 @@ class UploadServiceImplTest {
         assertThat(result).startsWith("https://cdn.test.com/missions/");
         assertThat(result).endsWith(".webp");
     }
+
+    @Test
+    @DisplayName("upload - image/jpeg Content-Type이면 .jpg 확장자로 변환된다")
+    void upload_jpegContentType_returnsJpgExtension() {
+        // given
+        MockMultipartFile file =
+                new MockMultipartFile("file", "photo.jpeg", "image/jpeg", new byte[1024]);
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenReturn(PutObjectResponse.builder().build());
+
+        // when
+        String result = uploadService.upload(file, UploadType.PROFILE);
+
+        // then
+        assertThat(result).startsWith("https://cdn.test.com/profiles/");
+        assertThat(result).endsWith(".jpg");
+    }
 }

--- a/src/test/java/com/project/domain/upload/service/UploadServiceImplTest.java
+++ b/src/test/java/com/project/domain/upload/service/UploadServiceImplTest.java
@@ -1,0 +1,155 @@
+package com.project.domain.upload.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.project.domain.upload.enums.UploadType;
+import com.project.global.exception.ApplicationException;
+import com.project.global.exception.code.UploadErrorCode;
+
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+@ExtendWith(MockitoExtension.class)
+class UploadServiceImplTest {
+
+    @Mock private S3Client s3Client;
+
+    @InjectMocks private UploadServiceImpl uploadService;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(uploadService, "bucket", "test-bucket");
+        ReflectionTestUtils.setField(uploadService, "cdnBaseUrl", "https://cdn.test.com");
+    }
+
+    @Test
+    @DisplayName("upload - 유효한 이미지 파일을 업로드하면 CDN URL을 반환한다")
+    void upload_validFile_returnsCdnUrl() {
+        // given
+        MockMultipartFile file =
+                new MockMultipartFile("file", "test.png", "image/png", new byte[1024]);
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenReturn(PutObjectResponse.builder().build());
+
+        // when
+        String result = uploadService.upload(file, UploadType.REWARD);
+
+        // then
+        assertThat(result).startsWith("https://cdn.test.com/rewards/");
+        assertThat(result).endsWith(".png");
+        verify(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+    }
+
+    @Test
+    @DisplayName("upload - 파일이 null이면 FILE_REQUIRED 예외가 발생한다")
+    void upload_nullFile_throwsFileRequired() {
+        // when & then
+        assertThatThrownBy(() -> uploadService.upload(null, UploadType.REWARD))
+                .isInstanceOf(ApplicationException.class)
+                .satisfies(
+                        e ->
+                                assertThat(((ApplicationException) e).getCode())
+                                        .isEqualTo(UploadErrorCode.FILE_REQUIRED));
+    }
+
+    @Test
+    @DisplayName("upload - 빈 파일이면 FILE_REQUIRED 예외가 발생한다")
+    void upload_emptyFile_throwsFileRequired() {
+        // given
+        MockMultipartFile file =
+                new MockMultipartFile("file", "test.png", "image/png", new byte[0]);
+
+        // when & then
+        assertThatThrownBy(() -> uploadService.upload(file, UploadType.REWARD))
+                .isInstanceOf(ApplicationException.class)
+                .satisfies(
+                        e ->
+                                assertThat(((ApplicationException) e).getCode())
+                                        .isEqualTo(UploadErrorCode.FILE_REQUIRED));
+    }
+
+    @Test
+    @DisplayName("upload - 5MB를 초과하면 FILE_TOO_LARGE 예외가 발생한다")
+    void upload_fileTooLarge_throwsFileTooLarge() {
+        // given
+        byte[] largeContent = new byte[5 * 1024 * 1024 + 1];
+        MockMultipartFile file =
+                new MockMultipartFile("file", "large.png", "image/png", largeContent);
+
+        // when & then
+        assertThatThrownBy(() -> uploadService.upload(file, UploadType.REWARD))
+                .isInstanceOf(ApplicationException.class)
+                .satisfies(
+                        e ->
+                                assertThat(((ApplicationException) e).getCode())
+                                        .isEqualTo(UploadErrorCode.FILE_TOO_LARGE));
+    }
+
+    @Test
+    @DisplayName("upload - 지원하지 않는 MIME 타입이면 INVALID_MIME_TYPE 예외가 발생한다")
+    void upload_invalidMimeType_throwsInvalidMimeType() {
+        // given
+        MockMultipartFile file =
+                new MockMultipartFile("file", "test.gif", "image/gif", new byte[1024]);
+
+        // when & then
+        assertThatThrownBy(() -> uploadService.upload(file, UploadType.REWARD))
+                .isInstanceOf(ApplicationException.class)
+                .satisfies(
+                        e ->
+                                assertThat(((ApplicationException) e).getCode())
+                                        .isEqualTo(UploadErrorCode.INVALID_MIME_TYPE));
+    }
+
+    @Test
+    @DisplayName("upload - S3 업로드 실패 시 UPLOAD_FAILED 예외가 발생한다")
+    void upload_s3Failure_throwsUploadFailed() {
+        // given
+        MockMultipartFile file =
+                new MockMultipartFile("file", "test.png", "image/png", new byte[1024]);
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenThrow(S3Exception.builder().message("connection refused").build());
+
+        // when & then
+        assertThatThrownBy(() -> uploadService.upload(file, UploadType.REWARD))
+                .isInstanceOf(ApplicationException.class)
+                .satisfies(
+                        e ->
+                                assertThat(((ApplicationException) e).getCode())
+                                        .isEqualTo(UploadErrorCode.UPLOAD_FAILED));
+    }
+
+    @Test
+    @DisplayName("upload - UploadType에 따라 올바른 prefix가 CDN URL에 포함된다")
+    void upload_differentTypes_usesCorrectPrefix() {
+        // given
+        MockMultipartFile file =
+                new MockMultipartFile("file", "test.webp", "image/webp", new byte[1024]);
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenReturn(PutObjectResponse.builder().build());
+
+        // when
+        String result = uploadService.upload(file, UploadType.MISSION);
+
+        // then
+        assertThat(result).startsWith("https://cdn.test.com/missions/");
+        assertThat(result).endsWith(".webp");
+    }
+}


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

- closed: #103 
- jira: DABOM-416

---

## 🎯 목적

관리자 페이지에서 보상 썸네일, 프로필 이미지 등을 등록할 수 있도록 Cloudflare R2(S3 호환) 기반 이미지 업로드 API를 구현합니다. 업로드된 이미지는 CDN URL로 반환되어 이후 리소스 생성 시 참조됩니다.

## 📝 변경 사항

- AWS SDK v2 S3 의존성 추가 및 R2 연결 설정 (`R2Config`, `application.yml`)
- `POST /uploads/images` Admin 전용 엔드포인트 구현
- 파일 검증 로직 구현 (MIME 타입, 파일 크기 5MB 제한)
- `UploadType` enum으로 업로드 경로 prefix 관리 (REWARD, PROFILE, MISSION)
- `UploadErrorCode` 에러코드 4건 정의 (UPLOAD_001~004)
- 확장자 추출을 파일명 기반에서 Content-Type 기반으로 변경 (PR 리뷰 반영)
- catch 범위를 `Exception`에서 `IOException | SdkException`으로 구체화 (PR 리뷰 반영)
- SonarQube 정적 분석 이슈 수정 (long 리터럴, assertion 체이닝)
- `UploadServiceImpl` 단위 테스트 8건 추가

## 📂 변경 범위

| 도메인 | controller | service | repository | entity | infra | global |
| :----: | :--------: | :-----: | :--------: | :----: | :---: | :----: |
| upload |    [x]     |   [x]   |            |        |       |  [x]   |

---

## 🖥️ 주요 코드 설명

```java
// UploadController — Admin 전용 이미지 업로드 엔드포인트
@PostMapping(value = "/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@AdminOnly
@ResponseStatus(HttpStatus.CREATED)
@Operation(summary = "이미지 업로드", description = "이미지를 R2에 업로드하고 CDN URL을 반환합니다.")
public ApiResponse<UploadResponse> uploadImage(
        @RequestParam("file") MultipartFile file, @RequestParam("type") UploadType type) {
    String cdnUrl = uploadService.upload(file, type);
    return ApiResponse.created(UploadResponse.from(cdnUrl));
}
```

```java
// extractExtension — Content-Type 기반으로 확장자 결정 (파일명 기반 대비 안전)
private String extractExtension(String contentType) {
    if ("image/png".equals(contentType)) {
        return "png";
    }
    if ("image/jpeg".equals(contentType)) {
        return "jpg";
    }
    if ("image/webp".equals(contentType)) {
        return "webp";
    }
    throw new ApplicationException(UploadErrorCode.INVALID_MIME_TYPE);
}
```

## 💬 리뷰어에게

- R2는 S3 호환 API를 제공하므로 AWS SDK S3 클라이언트를 그대로 사용합니다.
- DB 영속화 없이 R2 업로드 후 CDN URL만 반환하는 구조이므로 entity/repository가 없습니다.
- `@Value`로 주입되는 R2 설정값은 모두 환경변수(`${R2_ENDPOINT}` 등)로 관리됩니다.
- Service는 `String`(CDN URL)을 반환하고 Controller에서 DTO 변환합니다 (styleguide 섹션 4 준수).

---

## 📋 체크리스트

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [x] 전체 변경사항이 500줄을 넘지 않는가?

**코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → Repository → Entity`)
- [x] Setter 없이 비즈니스 메서드로 상태를 변경하는가?
- [x] `@Transactional`은 Service에만 선언했는가?

**테스트**
- [x] 신규 비즈니스 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

- 단위 테스트 8건: 정상 업로드, null/empty 파일, 크기 초과(경계값), 잘못된 MIME, S3 장애, UploadType별 prefix, JPEG→.jpg 확장자 변환 검증
- `spring.servlet.multipart` 설정(5MB)과 서비스 레벨 검증으로 파일 크기를 이중 체크합니다
- API 명세서(`API_SPECIFICATION.md`)도 Content-Type 기반 확장자 결정으로 동기화 완료
