### PR TITLE
[DABOM-483] admin dashboard api 구현

### DIFF
--- a/src/main/java/com/project/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/project/domain/admin/controller/AdminController.java
@@ -79,8 +79,7 @@ public class AdminController {
     @GetMapping("/dashboard")
     @AdminOnly
     @Operation(summary = "관리자 대시보드", description = "시스템 전체 통계를 조회합니다.")
-    public ApiResponse<AdminDashboardResponse> getDashboard(
-            @Parameter(hidden = true) @AdminId Long adminId) {
+    public ApiResponse<AdminDashboardResponse> getDashboard() {
         return ApiResponse.success(
                 AdminDashboardResponse.from(adminDashboardService.getDashboard()));
     }

--- a/src/main/java/com/project/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/project/domain/admin/controller/AdminController.java
@@ -81,6 +81,7 @@ public class AdminController {
     @Operation(summary = "관리자 대시보드", description = "시스템 전체 통계를 조회합니다.")
     public ApiResponse<AdminDashboardResponse> getDashboard(
             @Parameter(hidden = true) @AdminId Long adminId) {
-        return ApiResponse.success(adminDashboardService.getDashboard());
+        return ApiResponse.success(
+                AdminDashboardResponse.from(adminDashboardService.getDashboard()));
     }
 }

--- a/src/main/java/com/project/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/project/domain/admin/controller/AdminController.java
@@ -15,7 +15,9 @@ import com.project.common.auth.aop.AdminId;
 import com.project.common.auth.aop.AdminOnly;
 import com.project.domain.admin.dto.request.AdminRefreshRequest;
 import com.project.domain.admin.dto.request.AdminSignInRequest;
+import com.project.domain.admin.dto.response.AdminDashboardResponse;
 import com.project.domain.admin.dto.response.AdminMeResponse;
+import com.project.domain.admin.service.AdminDashboardService;
 import com.project.domain.admin.service.AdminService;
 import com.project.domain.customer.dto.response.SignInResponse;
 import com.project.domain.customer.dto.response.SignUpResponse;
@@ -33,6 +35,7 @@ import lombok.RequiredArgsConstructor;
 public class AdminController {
 
     private final AdminService adminService;
+    private final AdminDashboardService adminDashboardService;
 
     @PostMapping("/login")
     @Operation(summary = "관리자 로그인", description = "관리자 이메일/비밀번호로 로그인합니다.")
@@ -71,5 +74,13 @@ public class AdminController {
     public ApiResponse<Void> logout() {
         // 서버 측 처리 없음 — 클라이언트가 토큰을 삭제
         return ApiResponse.success(null);
+    }
+
+    @GetMapping("/dashboard")
+    @AdminOnly
+    @Operation(summary = "관리자 대시보드", description = "시스템 전체 통계를 조회합니다.")
+    public ApiResponse<AdminDashboardResponse> getDashboard(
+            @Parameter(hidden = true) @AdminId Long adminId) {
+        return ApiResponse.success(adminDashboardService.getDashboard());
     }
 }

--- a/src/main/java/com/project/domain/admin/dto/response/AdminDashboardResponse.java
+++ b/src/main/java/com/project/domain/admin/dto/response/AdminDashboardResponse.java
@@ -1,0 +1,20 @@
+package com.project.domain.admin.dto.response;
+
+import java.time.Instant;
+import java.util.List;
+
+public record AdminDashboardResponse(
+        long totalFamilies,
+        long activeFamilies,
+        long totalUsers,
+        long blockedUsers,
+        long todayEvents,
+        long currentTps,
+        SystemHealthResponse systemHealth,
+        List<RecentBlockResponse> recentBlocks) {
+
+    public record SystemHealthResponse(String redis, String kafka, String mysql) {}
+
+    public record RecentBlockResponse(
+            Long familyId, Long customerId, String reason, Instant blockedAt) {}
+}

--- a/src/main/java/com/project/domain/admin/dto/response/AdminDashboardResponse.java
+++ b/src/main/java/com/project/domain/admin/dto/response/AdminDashboardResponse.java
@@ -3,6 +3,8 @@ package com.project.domain.admin.dto.response;
 import java.time.Instant;
 import java.util.List;
 
+import com.project.domain.admin.model.AdminDashboard;
+
 public record AdminDashboardResponse(
         long totalFamilies,
         long activeFamilies,
@@ -13,8 +15,31 @@ public record AdminDashboardResponse(
         SystemHealthResponse systemHealth,
         List<RecentBlockResponse> recentBlocks) {
 
-    public record SystemHealthResponse(String redis, String kafka, String mysql) {}
+    public static AdminDashboardResponse from(AdminDashboard dashboard) {
+        return new AdminDashboardResponse(
+                dashboard.totalFamilies(),
+                dashboard.activeFamilies(),
+                dashboard.totalUsers(),
+                dashboard.blockedUsers(),
+                dashboard.todayEvents(),
+                dashboard.currentTps(),
+                SystemHealthResponse.from(dashboard.systemHealth()),
+                dashboard.recentBlocks().stream().map(RecentBlockResponse::from).toList());
+    }
+
+    public record SystemHealthResponse(String redis, String kafka, String mysql) {
+
+        public static SystemHealthResponse from(AdminDashboard.SystemHealth health) {
+            return new SystemHealthResponse(health.redis(), health.kafka(), health.mysql());
+        }
+    }
 
     public record RecentBlockResponse(
-            Long familyId, Long customerId, String reason, Instant blockedAt) {}
+            Long familyId, Long customerId, String reason, Instant blockedAt) {
+
+        public static RecentBlockResponse from(AdminDashboard.RecentBlock block) {
+            return new RecentBlockResponse(
+                    block.familyId(), block.customerId(), block.reason(), block.blockedAt());
+        }
+    }
 }

--- a/src/main/java/com/project/domain/admin/model/AdminDashboard.java
+++ b/src/main/java/com/project/domain/admin/model/AdminDashboard.java
@@ -1,0 +1,19 @@
+package com.project.domain.admin.model;
+
+import java.time.Instant;
+import java.util.List;
+
+public record AdminDashboard(
+        long totalFamilies,
+        long activeFamilies,
+        long totalUsers,
+        long blockedUsers,
+        long todayEvents,
+        long currentTps,
+        SystemHealth systemHealth,
+        List<RecentBlock> recentBlocks) {
+
+    public record SystemHealth(String redis, String kafka, String mysql) {}
+
+    public record RecentBlock(Long familyId, Long customerId, String reason, Instant blockedAt) {}
+}

--- a/src/main/java/com/project/domain/admin/service/AdminDashboardService.java
+++ b/src/main/java/com/project/domain/admin/service/AdminDashboardService.java
@@ -1,7 +1,7 @@
 package com.project.domain.admin.service;
 
-import com.project.domain.admin.dto.response.AdminDashboardResponse;
+import com.project.domain.admin.model.AdminDashboard;
 
 public interface AdminDashboardService {
-    AdminDashboardResponse getDashboard();
+    AdminDashboard getDashboard();
 }

--- a/src/main/java/com/project/domain/admin/service/AdminDashboardService.java
+++ b/src/main/java/com/project/domain/admin/service/AdminDashboardService.java
@@ -1,0 +1,7 @@
+package com.project.domain.admin.service;
+
+import com.project.domain.admin.dto.response.AdminDashboardResponse;
+
+public interface AdminDashboardService {
+    AdminDashboardResponse getDashboard();
+}

--- a/src/main/java/com/project/domain/admin/service/AdminDashboardServiceImpl.java
+++ b/src/main/java/com/project/domain/admin/service/AdminDashboardServiceImpl.java
@@ -1,0 +1,117 @@
+package com.project.domain.admin.service;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import org.springframework.boot.actuate.health.HealthComponent;
+import org.springframework.boot.actuate.health.HealthEndpoint;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.boot.actuate.health.SystemHealth;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.project.domain.admin.dto.response.AdminDashboardResponse;
+import com.project.domain.admin.dto.response.AdminDashboardResponse.RecentBlockResponse;
+import com.project.domain.admin.dto.response.AdminDashboardResponse.SystemHealthResponse;
+import com.project.domain.customer.entity.CustomerQuota;
+import com.project.domain.customer.repository.CustomerQuotaRepository;
+import com.project.domain.customer.repository.CustomerRepository;
+import com.project.domain.family.repository.FamilyMemberRepository;
+import com.project.domain.family.repository.FamilyRepository;
+import com.project.domain.usagerecord.repository.UsageRecordRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminDashboardServiceImpl implements AdminDashboardService {
+
+    private final FamilyRepository familyRepository;
+    private final FamilyMemberRepository familyMemberRepository;
+    private final CustomerRepository customerRepository;
+    private final CustomerQuotaRepository customerQuotaRepository;
+    private final UsageRecordRepository usageRecordRepository;
+    private final HealthEndpoint healthEndpoint;
+    private final Clock clock;
+
+    @Override
+    public AdminDashboardResponse getDashboard() {
+        LocalDate today = LocalDate.now(clock);
+        LocalDate currentMonth = today.withDayOfMonth(1);
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        long totalFamilies = familyRepository.countByDeletedAtIsNull();
+        long activeFamilies = familyMemberRepository.countDistinctActiveFamilies();
+        long totalUsers = customerRepository.countByDeletedAtIsNull();
+        long blockedUsers =
+                customerQuotaRepository.countByIsBlockedTrueAndCurrentMonthAndDeletedAtIsNull(
+                        currentMonth);
+
+        LocalDateTime todayStart = LocalDateTime.of(today, LocalTime.MIN);
+        long todayEvents =
+                usageRecordRepository.countByEventTimeGreaterThanEqualAndDeletedAtIsNull(
+                        todayStart);
+
+        LocalDateTime oneMinuteAgo = now.minusSeconds(60);
+        long eventsLastMinute =
+                usageRecordRepository.countByEventTimeGreaterThanEqualAndDeletedAtIsNull(
+                        oneMinuteAgo);
+        long currentTps = eventsLastMinute / 60;
+
+        SystemHealthResponse systemHealth = buildSystemHealth();
+
+        List<RecentBlockResponse> recentBlocks = buildRecentBlocks(currentMonth);
+
+        return new AdminDashboardResponse(
+                totalFamilies,
+                activeFamilies,
+                totalUsers,
+                blockedUsers,
+                todayEvents,
+                currentTps,
+                systemHealth,
+                recentBlocks);
+    }
+
+    private SystemHealthResponse buildSystemHealth() {
+        SystemHealth health = (SystemHealth) healthEndpoint.health();
+        return new SystemHealthResponse(
+                getComponentStatus(health, "redis"),
+                getComponentStatus(health, "kafka"),
+                getComponentStatus(health, "db"));
+    }
+
+    private String getComponentStatus(SystemHealth health, String componentName) {
+        HealthComponent component = health.getComponents().get(componentName);
+        if (component == null) {
+            return "UNKNOWN";
+        }
+        Status status = component.getStatus();
+        return status.getCode();
+    }
+
+    private List<RecentBlockResponse> buildRecentBlocks(LocalDate currentMonth) {
+        List<CustomerQuota> blocked =
+                customerQuotaRepository
+                        .findTop10ByIsBlockedTrueAndCurrentMonthAndDeletedAtIsNullOrderByUpdatedAtDesc(
+                                currentMonth);
+
+        return blocked.stream()
+                .map(
+                        q ->
+                                new RecentBlockResponse(
+                                        q.getFamilyId(),
+                                        q.getCustomerId(),
+                                        q.getBlockReason(),
+                                        q.getUpdatedAt() != null
+                                                ? q.getUpdatedAt()
+                                                        .atZone(java.time.ZoneId.systemDefault())
+                                                        .toInstant()
+                                                : null))
+                .toList();
+    }
+}

--- a/src/main/java/com/project/domain/admin/service/AdminDashboardServiceImpl.java
+++ b/src/main/java/com/project/domain/admin/service/AdminDashboardServiceImpl.java
@@ -4,7 +4,6 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.ZoneId;
 import java.util.List;
 
 import org.springframework.boot.actuate.health.HealthComponent;
@@ -27,6 +26,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AdminDashboardServiceImpl implements AdminDashboardService {
+
+    private static final String HEALTH_REDIS = "redis";
+    private static final String HEALTH_KAFKA = "kafka";
+    private static final String HEALTH_DB = "db";
+    private static final int TPS_WINDOW_SECONDS = 60;
 
     private final FamilyRepository familyRepository;
     private final FamilyMemberRepository familyMemberRepository;
@@ -54,11 +58,11 @@ public class AdminDashboardServiceImpl implements AdminDashboardService {
                 usageRecordRepository.countByEventTimeGreaterThanEqualAndDeletedAtIsNull(
                         todayStart);
 
-        LocalDateTime oneMinuteAgo = now.minusSeconds(60);
+        LocalDateTime oneMinuteAgo = now.minusSeconds(TPS_WINDOW_SECONDS);
         long eventsLastMinute =
                 usageRecordRepository.countByEventTimeGreaterThanEqualAndDeletedAtIsNull(
                         oneMinuteAgo);
-        long currentTps = eventsLastMinute / 60;
+        long currentTps = Math.round(eventsLastMinute / (double) TPS_WINDOW_SECONDS);
 
         AdminDashboard.SystemHealth systemHealth = buildSystemHealth();
 
@@ -79,9 +83,9 @@ public class AdminDashboardServiceImpl implements AdminDashboardService {
         org.springframework.boot.actuate.health.SystemHealth health =
                 (org.springframework.boot.actuate.health.SystemHealth) healthEndpoint.health();
         return new AdminDashboard.SystemHealth(
-                getComponentStatus(health, "redis"),
-                getComponentStatus(health, "kafka"),
-                getComponentStatus(health, "db"));
+                getComponentStatus(health, HEALTH_REDIS),
+                getComponentStatus(health, HEALTH_KAFKA),
+                getComponentStatus(health, HEALTH_DB));
     }
 
     private String getComponentStatus(
@@ -109,7 +113,7 @@ public class AdminDashboardServiceImpl implements AdminDashboardService {
                                         q.getBlockReason(),
                                         q.getUpdatedAt() != null
                                                 ? q.getUpdatedAt()
-                                                        .atZone(ZoneId.systemDefault())
+                                                        .atZone(clock.getZone())
                                                         .toInstant()
                                                 : null))
                 .toList();

--- a/src/main/java/com/project/domain/admin/service/AdminDashboardServiceImpl.java
+++ b/src/main/java/com/project/domain/admin/service/AdminDashboardServiceImpl.java
@@ -4,18 +4,16 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.List;
 
 import org.springframework.boot.actuate.health.HealthComponent;
 import org.springframework.boot.actuate.health.HealthEndpoint;
 import org.springframework.boot.actuate.health.Status;
-import org.springframework.boot.actuate.health.SystemHealth;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.project.domain.admin.dto.response.AdminDashboardResponse;
-import com.project.domain.admin.dto.response.AdminDashboardResponse.RecentBlockResponse;
-import com.project.domain.admin.dto.response.AdminDashboardResponse.SystemHealthResponse;
+import com.project.domain.admin.model.AdminDashboard;
 import com.project.domain.customer.entity.CustomerQuota;
 import com.project.domain.customer.repository.CustomerQuotaRepository;
 import com.project.domain.customer.repository.CustomerRepository;
@@ -39,7 +37,7 @@ public class AdminDashboardServiceImpl implements AdminDashboardService {
     private final Clock clock;
 
     @Override
-    public AdminDashboardResponse getDashboard() {
+    public AdminDashboard getDashboard() {
         LocalDate today = LocalDate.now(clock);
         LocalDate currentMonth = today.withDayOfMonth(1);
         LocalDateTime now = LocalDateTime.now(clock);
@@ -62,11 +60,11 @@ public class AdminDashboardServiceImpl implements AdminDashboardService {
                         oneMinuteAgo);
         long currentTps = eventsLastMinute / 60;
 
-        SystemHealthResponse systemHealth = buildSystemHealth();
+        AdminDashboard.SystemHealth systemHealth = buildSystemHealth();
 
-        List<RecentBlockResponse> recentBlocks = buildRecentBlocks(currentMonth);
+        List<AdminDashboard.RecentBlock> recentBlocks = buildRecentBlocks(currentMonth);
 
-        return new AdminDashboardResponse(
+        return new AdminDashboard(
                 totalFamilies,
                 activeFamilies,
                 totalUsers,
@@ -77,15 +75,17 @@ public class AdminDashboardServiceImpl implements AdminDashboardService {
                 recentBlocks);
     }
 
-    private SystemHealthResponse buildSystemHealth() {
-        SystemHealth health = (SystemHealth) healthEndpoint.health();
-        return new SystemHealthResponse(
+    private AdminDashboard.SystemHealth buildSystemHealth() {
+        org.springframework.boot.actuate.health.SystemHealth health =
+                (org.springframework.boot.actuate.health.SystemHealth) healthEndpoint.health();
+        return new AdminDashboard.SystemHealth(
                 getComponentStatus(health, "redis"),
                 getComponentStatus(health, "kafka"),
                 getComponentStatus(health, "db"));
     }
 
-    private String getComponentStatus(SystemHealth health, String componentName) {
+    private String getComponentStatus(
+            org.springframework.boot.actuate.health.SystemHealth health, String componentName) {
         HealthComponent component = health.getComponents().get(componentName);
         if (component == null) {
             return "UNKNOWN";
@@ -94,7 +94,7 @@ public class AdminDashboardServiceImpl implements AdminDashboardService {
         return status.getCode();
     }
 
-    private List<RecentBlockResponse> buildRecentBlocks(LocalDate currentMonth) {
+    private List<AdminDashboard.RecentBlock> buildRecentBlocks(LocalDate currentMonth) {
         List<CustomerQuota> blocked =
                 customerQuotaRepository
                         .findTop10ByIsBlockedTrueAndCurrentMonthAndDeletedAtIsNullOrderByUpdatedAtDesc(
@@ -103,13 +103,13 @@ public class AdminDashboardServiceImpl implements AdminDashboardService {
         return blocked.stream()
                 .map(
                         q ->
-                                new RecentBlockResponse(
+                                new AdminDashboard.RecentBlock(
                                         q.getFamilyId(),
                                         q.getCustomerId(),
                                         q.getBlockReason(),
                                         q.getUpdatedAt() != null
                                                 ? q.getUpdatedAt()
-                                                        .atZone(java.time.ZoneId.systemDefault())
+                                                        .atZone(ZoneId.systemDefault())
                                                         .toInstant()
                                                 : null))
                 .toList();

--- a/src/main/java/com/project/domain/customer/repository/CustomerQuotaRepository.java
+++ b/src/main/java/com/project/domain/customer/repository/CustomerQuotaRepository.java
@@ -1,6 +1,7 @@
 package com.project.domain.customer.repository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,10 @@ import com.project.domain.customer.entity.CustomerQuota;
 public interface CustomerQuotaRepository extends JpaRepository<CustomerQuota, Long> {
     Optional<CustomerQuota> findByFamilyIdAndCustomerIdAndCurrentMonthAndDeletedAtIsNull(
             Long familyId, Long customerId, LocalDate currentMonth);
+
+    long countByIsBlockedTrueAndCurrentMonthAndDeletedAtIsNull(LocalDate currentMonth);
+
+    List<CustomerQuota>
+            findTop10ByIsBlockedTrueAndCurrentMonthAndDeletedAtIsNullOrderByUpdatedAtDesc(
+                    LocalDate currentMonth);
 }

--- a/src/main/java/com/project/domain/customer/repository/CustomerRepository.java
+++ b/src/main/java/com/project/domain/customer/repository/CustomerRepository.java
@@ -8,4 +8,6 @@ public interface CustomerRepository extends JpaRepository<Customer, Long> {
     Customer findByPhoneNumber(String phoneNumber);
 
     boolean existsByPhoneNumber(String phoneNumber);
+
+    long countByDeletedAtIsNull();
 }

--- a/src/main/java/com/project/domain/family/repository/FamilyMemberRepository.java
+++ b/src/main/java/com/project/domain/family/repository/FamilyMemberRepository.java
@@ -21,4 +21,9 @@ public interface FamilyMemberRepository extends JpaRepository<FamilyMember, Long
     Optional<Long> findFamilyIdByCustomerId(Long customerId);
 
     boolean existsByCustomerId(Long customerId);
+
+    @Query(
+            "SELECT COUNT(DISTINCT fm.familyId) FROM FamilyMember fm"
+                    + " WHERE fm.deletedAt IS NULL")
+    long countDistinctActiveFamilies();
 }

--- a/src/main/java/com/project/domain/family/repository/FamilyRepository.java
+++ b/src/main/java/com/project/domain/family/repository/FamilyRepository.java
@@ -4,4 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.project.domain.family.entity.Family;
 
-public interface FamilyRepository extends JpaRepository<Family, Long> {}
+public interface FamilyRepository extends JpaRepository<Family, Long> {
+    long countByDeletedAtIsNull();
+}

--- a/src/main/java/com/project/domain/usagerecord/entity/UsageRecord.java
+++ b/src/main/java/com/project/domain/usagerecord/entity/UsageRecord.java
@@ -1,0 +1,62 @@
+package com.project.domain.usagerecord.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import com.project.common.util.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "usage_record")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UsageRecord extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "event_id", nullable = false, length = 50, unique = true)
+    private String eventId;
+
+    @Column(name = "customer_id", nullable = false)
+    private Long customerId;
+
+    @Column(name = "family_id", nullable = false)
+    private Long familyId;
+
+    @Column(name = "bytes_used", nullable = false)
+    private Long bytesUsed;
+
+    @Column(name = "app_id", length = 100)
+    private String appId;
+
+    @Column(name = "event_time", nullable = false)
+    private LocalDateTime eventTime;
+
+    @Builder
+    public UsageRecord(
+            String eventId,
+            Long customerId,
+            Long familyId,
+            Long bytesUsed,
+            String appId,
+            LocalDateTime eventTime) {
+        this.eventId = eventId;
+        this.customerId = customerId;
+        this.familyId = familyId;
+        this.bytesUsed = bytesUsed;
+        this.appId = appId;
+        this.eventTime = eventTime;
+    }
+}

--- a/src/main/java/com/project/domain/usagerecord/repository/UsageRecordRepository.java
+++ b/src/main/java/com/project/domain/usagerecord/repository/UsageRecordRepository.java
@@ -1,0 +1,11 @@
+package com.project.domain.usagerecord.repository;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.project.domain.usagerecord.entity.UsageRecord;
+
+public interface UsageRecordRepository extends JpaRepository<UsageRecord, Long> {
+    long countByEventTimeGreaterThanEqualAndDeletedAtIsNull(LocalDateTime from);
+}

--- a/src/test/java/com/project/domain/admin/service/AdminDashboardServiceImplTest.java
+++ b/src/test/java/com/project/domain/admin/service/AdminDashboardServiceImplTest.java
@@ -195,8 +195,8 @@ class AdminDashboardServiceImplTest {
     }
 
     @Test
-    @DisplayName("getDashboard - 최근 1분 이벤트가 60 미만이면 currentTps는 0이다")
-    void getDashboard_lowEventCount_tpsIsZero() {
+    @DisplayName("getDashboard - TPS는 최근 1분 이벤트 수를 반올림하여 계산한다")
+    void getDashboard_tpsRoundsCorrectly() {
         // given
         given(familyRepository.countByDeletedAtIsNull()).willReturn(10L);
         given(familyMemberRepository.countDistinctActiveFamilies()).willReturn(10L);
@@ -224,7 +224,7 @@ class AdminDashboardServiceImplTest {
 
         // then
         assertThat(result.todayEvents()).isEqualTo(100L);
-        assertThat(result.currentTps()).isEqualTo(0L);
+        assertThat(result.currentTps()).isEqualTo(1L);
     }
 
     private void stubCountQueries() {

--- a/src/test/java/com/project/domain/admin/service/AdminDashboardServiceImplTest.java
+++ b/src/test/java/com/project/domain/admin/service/AdminDashboardServiceImplTest.java
@@ -114,7 +114,6 @@ class AdminDashboardServiceImplTest {
         stubCountQueries();
         mockHealthEndpoint("UP", "UP", "UP");
 
-        LocalDateTime blockedTime = LocalDateTime.of(2026, 3, 15, 10, 30, 0);
         CustomerQuota blocked =
                 CustomerQuota.builder()
                         .customerId(12346L)

--- a/src/test/java/com/project/domain/admin/service/AdminDashboardServiceImplTest.java
+++ b/src/test/java/com/project/domain/admin/service/AdminDashboardServiceImplTest.java
@@ -1,0 +1,257 @@
+package com.project.domain.admin.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthComponent;
+import org.springframework.boot.actuate.health.HealthEndpoint;
+
+import com.project.domain.admin.model.AdminDashboard;
+import com.project.domain.customer.entity.CustomerQuota;
+import com.project.domain.customer.repository.CustomerQuotaRepository;
+import com.project.domain.customer.repository.CustomerRepository;
+import com.project.domain.family.repository.FamilyMemberRepository;
+import com.project.domain.family.repository.FamilyRepository;
+import com.project.domain.usagerecord.repository.UsageRecordRepository;
+
+@ExtendWith(MockitoExtension.class)
+class AdminDashboardServiceImplTest {
+
+    private static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
+    private static final Clock FIXED_CLOCK =
+            Clock.fixed(Instant.parse("2026-03-17T01:30:00Z"), ZONE);
+    private static final LocalDate TODAY = LocalDate.of(2026, 3, 17);
+    private static final LocalDate CURRENT_MONTH = LocalDate.of(2026, 3, 1);
+    private static final LocalDateTime TODAY_START = LocalDateTime.of(TODAY, LocalTime.MIN);
+    private static final LocalDateTime NOW = LocalDateTime.now(FIXED_CLOCK);
+    private static final LocalDateTime ONE_MINUTE_AGO = NOW.minusSeconds(60);
+
+    @Mock private FamilyRepository familyRepository;
+    @Mock private FamilyMemberRepository familyMemberRepository;
+    @Mock private CustomerRepository customerRepository;
+    @Mock private CustomerQuotaRepository customerQuotaRepository;
+    @Mock private UsageRecordRepository usageRecordRepository;
+    @Mock private HealthEndpoint healthEndpoint;
+
+    private AdminDashboardServiceImpl adminDashboardService;
+
+    @BeforeEach
+    void setUp() {
+        adminDashboardService =
+                new AdminDashboardServiceImpl(
+                        familyRepository,
+                        familyMemberRepository,
+                        customerRepository,
+                        customerQuotaRepository,
+                        usageRecordRepository,
+                        healthEndpoint,
+                        FIXED_CLOCK);
+    }
+
+    @Test
+    @DisplayName("getDashboard - 시스템 전체 통계를 정상적으로 집계한다")
+    void getDashboard_returnsAggregatedStats() {
+        // given
+        given(familyRepository.countByDeletedAtIsNull()).willReturn(250000L);
+        given(familyMemberRepository.countDistinctActiveFamilies()).willReturn(248500L);
+        given(customerRepository.countByDeletedAtIsNull()).willReturn(1000000L);
+        given(
+                        customerQuotaRepository
+                                .countByIsBlockedTrueAndCurrentMonthAndDeletedAtIsNull(
+                                        CURRENT_MONTH))
+                .willReturn(1523L);
+        given(usageRecordRepository.countByEventTimeGreaterThanEqualAndDeletedAtIsNull(TODAY_START))
+                .willReturn(432000L);
+        given(
+                        usageRecordRepository.countByEventTimeGreaterThanEqualAndDeletedAtIsNull(
+                                ONE_MINUTE_AGO))
+                .willReturn(300L);
+        mockHealthEndpoint("UP", "UP", "UP");
+        given(
+                        customerQuotaRepository
+                                .findTop10ByIsBlockedTrueAndCurrentMonthAndDeletedAtIsNullOrderByUpdatedAtDesc(
+                                        CURRENT_MONTH))
+                .willReturn(List.of());
+
+        // when
+        AdminDashboard result = adminDashboardService.getDashboard();
+
+        // then
+        assertThat(result.totalFamilies()).isEqualTo(250000L);
+        assertThat(result.activeFamilies()).isEqualTo(248500L);
+        assertThat(result.totalUsers()).isEqualTo(1000000L);
+        assertThat(result.blockedUsers()).isEqualTo(1523L);
+        assertThat(result.todayEvents()).isEqualTo(432000L);
+        assertThat(result.currentTps()).isEqualTo(5L);
+        assertThat(result.systemHealth().redis()).isEqualTo("UP");
+        assertThat(result.systemHealth().kafka()).isEqualTo("UP");
+        assertThat(result.systemHealth().mysql()).isEqualTo("UP");
+        assertThat(result.recentBlocks()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getDashboard - recentBlocks를 CustomerQuota에서 올바르게 변환한다")
+    void getDashboard_mapsRecentBlocksCorrectly() {
+        // given
+        stubCountQueries();
+        mockHealthEndpoint("UP", "UP", "UP");
+
+        LocalDateTime blockedTime = LocalDateTime.of(2026, 3, 15, 10, 30, 0);
+        CustomerQuota blocked =
+                CustomerQuota.builder()
+                        .customerId(12346L)
+                        .familyId(100L)
+                        .monthlyLimitBytes(10_000_000L)
+                        .monthlyUsedBytes(10_000_000L)
+                        .currentMonth(CURRENT_MONTH)
+                        .isBlocked(true)
+                        .blockReason("MONTHLY_LIMIT_EXCEEDED")
+                        .build();
+        // updatedAt은 BaseEntity의 JPA Auditing으로 설정되므로 테스트에서는 null
+
+        given(
+                        customerQuotaRepository
+                                .findTop10ByIsBlockedTrueAndCurrentMonthAndDeletedAtIsNullOrderByUpdatedAtDesc(
+                                        CURRENT_MONTH))
+                .willReturn(List.of(blocked));
+
+        // when
+        AdminDashboard result = adminDashboardService.getDashboard();
+
+        // then
+        assertThat(result.recentBlocks()).hasSize(1);
+        AdminDashboard.RecentBlock block = result.recentBlocks().get(0);
+        assertThat(block.familyId()).isEqualTo(100L);
+        assertThat(block.customerId()).isEqualTo(12346L);
+        assertThat(block.reason()).isEqualTo("MONTHLY_LIMIT_EXCEEDED");
+    }
+
+    @Test
+    @DisplayName("getDashboard - 헬스 컴포넌트가 없으면 UNKNOWN을 반환한다")
+    void getDashboard_missingHealthComponent_returnsUnknown() {
+        // given
+        stubCountQueries();
+        given(
+                        customerQuotaRepository
+                                .findTop10ByIsBlockedTrueAndCurrentMonthAndDeletedAtIsNullOrderByUpdatedAtDesc(
+                                        CURRENT_MONTH))
+                .willReturn(List.of());
+
+        // redis만 존재, kafka/db 없음
+        org.springframework.boot.actuate.health.SystemHealth systemHealth =
+                mock(org.springframework.boot.actuate.health.SystemHealth.class);
+        Map<String, HealthComponent> components = new HashMap<>();
+        components.put("redis", Health.up().build());
+        given(systemHealth.getComponents()).willReturn(components);
+        given(healthEndpoint.health()).willReturn(systemHealth);
+
+        // when
+        AdminDashboard result = adminDashboardService.getDashboard();
+
+        // then
+        assertThat(result.systemHealth().redis()).isEqualTo("UP");
+        assertThat(result.systemHealth().kafka()).isEqualTo("UNKNOWN");
+        assertThat(result.systemHealth().mysql()).isEqualTo("UNKNOWN");
+    }
+
+    @Test
+    @DisplayName("getDashboard - 헬스 컴포넌트가 DOWN이면 DOWN을 반환한다")
+    void getDashboard_downHealthComponent_returnsDown() {
+        // given
+        stubCountQueries();
+        given(
+                        customerQuotaRepository
+                                .findTop10ByIsBlockedTrueAndCurrentMonthAndDeletedAtIsNullOrderByUpdatedAtDesc(
+                                        CURRENT_MONTH))
+                .willReturn(List.of());
+
+        mockHealthEndpoint("DOWN", "UP", "UP");
+
+        // when
+        AdminDashboard result = adminDashboardService.getDashboard();
+
+        // then
+        assertThat(result.systemHealth().redis()).isEqualTo("DOWN");
+        assertThat(result.systemHealth().kafka()).isEqualTo("UP");
+        assertThat(result.systemHealth().mysql()).isEqualTo("UP");
+    }
+
+    @Test
+    @DisplayName("getDashboard - 최근 1분 이벤트가 60 미만이면 currentTps는 0이다")
+    void getDashboard_lowEventCount_tpsIsZero() {
+        // given
+        given(familyRepository.countByDeletedAtIsNull()).willReturn(10L);
+        given(familyMemberRepository.countDistinctActiveFamilies()).willReturn(10L);
+        given(customerRepository.countByDeletedAtIsNull()).willReturn(50L);
+        given(
+                        customerQuotaRepository
+                                .countByIsBlockedTrueAndCurrentMonthAndDeletedAtIsNull(
+                                        CURRENT_MONTH))
+                .willReturn(0L);
+        given(usageRecordRepository.countByEventTimeGreaterThanEqualAndDeletedAtIsNull(TODAY_START))
+                .willReturn(100L);
+        given(
+                        usageRecordRepository.countByEventTimeGreaterThanEqualAndDeletedAtIsNull(
+                                ONE_MINUTE_AGO))
+                .willReturn(30L);
+        mockHealthEndpoint("UP", "UP", "UP");
+        given(
+                        customerQuotaRepository
+                                .findTop10ByIsBlockedTrueAndCurrentMonthAndDeletedAtIsNullOrderByUpdatedAtDesc(
+                                        CURRENT_MONTH))
+                .willReturn(List.of());
+
+        // when
+        AdminDashboard result = adminDashboardService.getDashboard();
+
+        // then
+        assertThat(result.todayEvents()).isEqualTo(100L);
+        assertThat(result.currentTps()).isEqualTo(0L);
+    }
+
+    private void stubCountQueries() {
+        given(familyRepository.countByDeletedAtIsNull()).willReturn(100L);
+        given(familyMemberRepository.countDistinctActiveFamilies()).willReturn(90L);
+        given(customerRepository.countByDeletedAtIsNull()).willReturn(500L);
+        given(
+                        customerQuotaRepository
+                                .countByIsBlockedTrueAndCurrentMonthAndDeletedAtIsNull(
+                                        CURRENT_MONTH))
+                .willReturn(5L);
+        given(usageRecordRepository.countByEventTimeGreaterThanEqualAndDeletedAtIsNull(TODAY_START))
+                .willReturn(1000L);
+        given(
+                        usageRecordRepository.countByEventTimeGreaterThanEqualAndDeletedAtIsNull(
+                                ONE_MINUTE_AGO))
+                .willReturn(60L);
+    }
+
+    private void mockHealthEndpoint(String redisStatus, String kafkaStatus, String dbStatus) {
+        org.springframework.boot.actuate.health.SystemHealth systemHealth =
+                mock(org.springframework.boot.actuate.health.SystemHealth.class);
+        Map<String, HealthComponent> components = new HashMap<>();
+        components.put("redis", Health.status(redisStatus).build());
+        components.put("kafka", Health.status(kafkaStatus).build());
+        components.put("db", Health.status(dbStatus).build());
+        given(systemHealth.getComponents()).willReturn(components);
+        given(healthEndpoint.health()).willReturn(systemHealth);
+    }
+}


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

- closed: #120
- jira: DABOM-483

---

## 🎯 목적

관리자가 시스템 전체 현황을 한눈에 파악할 수 있도록 대시보드 API(`GET /admin/dashboard`)를 제공합니다.
가족/사용자 통계, 차단 현황, 이벤트 통계, 시스템 헬스 정보를 집계하여 반환합니다.

## 📝 변경 사항

- `GET /admin/dashboard` 엔드포인트 추가 (`@AdminOnly` 인증 기반)
- `AdminDashboardService` / `AdminDashboardServiceImpl` 생성 (다중 Repository 집계 + Actuator 헬스 조회)
- `AdminDashboard` 도메인 모델 생성 (Service 반환용, styleguide 섹션 4 준수)
- `AdminDashboardResponse` 응답 DTO 생성 (`static from()` 패턴 적용)
- `UsageRecord` JPA Entity 및 `UsageRecordRepository` 생성 (기존에 누락된 `usage_record` 테이블 매핑)
- `FamilyRepository`, `FamilyMemberRepository`, `CustomerRepository`, `CustomerQuotaRepository`에 대시보드 통계용 count/find 메서드 추가

## 📂 변경 범위

| 도메인 | controller | service | repository | entity | infra | global |
| :----: | :--------: | :-----: | :--------: | :----: | :---: | :----: |
| admin |    [x]     |   [x]   |            |        |       |        |
| family |            |         |    [x]     |        |       |        |
| customer |            |         |    [x]     |        |       |        |
| usagerecord |            |         |    [x]     |  [x]   |       |        |

---

## 🖥️ 주요 코드 설명

```java
// AdminController — 대시보드 조회
@GetMapping("/dashboard")
@AdminOnly
@Operation(summary = "관리자 대시보드", description = "시스템 전체 통계를 조회합니다.")
public ApiResponse<AdminDashboardResponse> getDashboard(
        @Parameter(hidden = true) @AdminId Long adminId) {
    return ApiResponse.success(
            AdminDashboardResponse.from(adminDashboardService.getDashboard()));
}
```

```java
// AdminDashboardServiceImpl — 통계 집계 (주요 로직)
@Override
public AdminDashboard getDashboard() {
    long totalFamilies = familyRepository.countByDeletedAtIsNull();
    long activeFamilies = familyMemberRepository.countDistinctActiveFamilies();
    long totalUsers = customerRepository.countByDeletedAtIsNull();
    long blockedUsers = customerQuotaRepository
            .countByIsBlockedTrueAndCurrentMonthAndDeletedAtIsNull(currentMonth);
    long todayEvents = usageRecordRepository
            .countByEventTimeGreaterThanEqualAndDeletedAtIsNull(todayStart);
    // ...systemHealth (Actuator HealthEndpoint), recentBlocks (최근 차단 10건)
}
```

```java
// UsageRecord — 신규 JPA Entity (usage_record 테이블 매핑)
@Entity
@Table(name = "usage_record")
public class UsageRecord extends BaseEntity {
    private String eventId;   // UK
    private Long customerId;  // FK → customer
    private Long familyId;    // FK → family
    private Long bytesUsed;
    private String appId;
    private LocalDateTime eventTime;
}
```

## 💬 리뷰어에게

- styleguide 섹션 4 준수: `AdminDashboardService`는 `AdminDashboard` 도메인 모델을 반환하고, Controller에서 `AdminDashboardResponse.from()`으로 DTO 변환합니다.
- `UsageRecord` Entity는 기존에 DB 테이블만 존재하고 JPA 매핑이 없었던 `usage_record`를 Entity로 정의한 것입니다. 대시보드 외에도 향후 사용량 관련 기능에서 활용 가능합니다.
- `systemHealth`는 Spring Actuator `HealthEndpoint`를 통해 redis, kafka, db(mysql) 상태를 조회합니다. 해당 인프라가 연결되지 않은 경우 `"UNKNOWN"`을 반환합니다.
- `currentTps`는 최근 60초간 이벤트 수 / 60으로 근사값을 계산합니다.
- `recentBlocks`의 `blockedAt`은 `customer_quota.updated_at`을 활용합니다.

---

## 📋 체크리스트

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [x] 전체 변경사항이 500줄을 넘지 않는가?

**코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → Repository → Entity`)
- [x] Setter 없이 비즈니스 메서드로 상태를 변경하는가?
- [x] `@Transactional`은 Service에만 선언했는가?

**테스트**
- [ ] 신규 비즈니스 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

- 변경사항 총 290줄 (500줄 이내)
- 신규 파일 6개, 수정 파일 5개 (11개 파일 변경)
- 단위 테스트는 후속 작업으로 추가 예정
