### PR TITLE
[DABOM-498] 상태코드 개선 작업

### DIFF
--- a/src/main/java/com/project/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/project/domain/admin/controller/AdminController.java
@@ -2,10 +2,12 @@ package com.project.domain.admin.controller;
 
 import jakarta.validation.Valid;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.project.common.api.response.ApiResponse;
@@ -47,6 +49,7 @@ public class AdminController {
     }
 
     @PostMapping("/signup")
+    @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "관리자 회원가입", description = "관리자 이메일/비밀번호로 회원가입합니다.")
     public ApiResponse<SignUpResponse> signUp(
             @Valid @RequestBody AdminSignInRequest signInRequest) {

--- a/src/main/java/com/project/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/project/domain/admin/controller/AdminController.java
@@ -53,7 +53,7 @@ public class AdminController {
     @Operation(summary = "관리자 회원가입", description = "관리자 이메일/비밀번호로 회원가입합니다.")
     public ApiResponse<SignUpResponse> signUp(
             @Valid @RequestBody AdminSignInRequest signInRequest) {
-        return ApiResponse.success(
+        return ApiResponse.created(
                 adminService.signUp(signInRequest.email(), signInRequest.password()));
     }
 

--- a/src/main/java/com/project/domain/appeal/controller/AppealController.java
+++ b/src/main/java/com/project/domain/appeal/controller/AppealController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.project.common.api.response.ApiResponse;
@@ -97,6 +99,7 @@ public class AppealController {
 
     /** 이의제기 생성 처리 */
     @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "이의제기 생성")
     public ApiResponse<AppealCreateResponse> createAppeal(
             @Parameter(hidden = true) @CustomerId Long customerId,
@@ -121,6 +124,7 @@ public class AppealController {
 
     /** 이의제기 댓글 작성 처리 */
     @PostMapping("/{appealId}/comments")
+    @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "이의제기 댓글 작성")
     public ApiResponse<AppealCommentResponse> createComment(
             @Parameter(hidden = true) @CustomerId Long customerId,
@@ -143,6 +147,7 @@ public class AppealController {
 
     /** 긴급 쿼터 요청 처리 */
     @PostMapping("/emergency")
+    @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "긴급 쿼터 요청")
     public ApiResponse<EmergencyQuotaResponse> requestEmergencyQuota(
             @Parameter(hidden = true) @CustomerId Long customerId,

--- a/src/main/java/com/project/domain/customer/controller/CustomerController.java
+++ b/src/main/java/com/project/domain/customer/controller/CustomerController.java
@@ -2,11 +2,13 @@ package com.project.domain.customer.controller;
 
 import jakarta.validation.Valid;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.project.common.api.response.ApiResponse;
@@ -48,6 +50,7 @@ public class CustomerController {
     }
 
     @PostMapping("/signup")
+    @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "사용자 회원가입", description = "사용자 이메일/비밀번호로 회원가입합니다.")
     public ApiResponse<SignUpResponse> signUp(
             @Valid @RequestBody CustomerSignUpRequest requestDto) {

--- a/src/main/java/com/project/domain/customer/controller/CustomerController.java
+++ b/src/main/java/com/project/domain/customer/controller/CustomerController.java
@@ -54,7 +54,7 @@ public class CustomerController {
     @Operation(summary = "사용자 회원가입", description = "사용자 이메일/비밀번호로 회원가입합니다.")
     public ApiResponse<SignUpResponse> signUp(
             @Valid @RequestBody CustomerSignUpRequest requestDto) {
-        return ApiResponse.success(customerService.signUp(requestDto));
+        return ApiResponse.created(customerService.signUp(requestDto));
     }
 
     @PostMapping("/refresh")

--- a/src/main/java/com/project/domain/mission/controller/MissionController.java
+++ b/src/main/java/com/project/domain/mission/controller/MissionController.java
@@ -120,6 +120,6 @@ public class MissionController {
             @Parameter(hidden = true) @CustomerId Long customerId, @PathVariable Long missionId) {
         AuthContext auth = authContextService.resolve(customerId);
         MissionRequestResult result = missionService.requestMissionApproval(auth, missionId);
-        return ApiResponse.success(MissionRequestResponse.from(result));
+        return ApiResponse.created(MissionRequestResponse.from(result));
     }
 }

--- a/src/main/java/com/project/domain/mission/controller/MissionController.java
+++ b/src/main/java/com/project/domain/mission/controller/MissionController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.project.common.api.response.ApiResponse;
@@ -89,6 +91,7 @@ public class MissionController {
     /** OWNER가 미션을 생성한다. */
     @OwnerOnly
     @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "미션 생성")
     public ApiResponse<CreateMissionResponse> createMission(
             @Parameter(hidden = true) @CustomerId Long customerId,
@@ -111,6 +114,7 @@ public class MissionController {
 
     /** MEMBER가 본인 미션 완료 요청을 생성한다. */
     @PostMapping("/{missionId}/request")
+    @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "미션 완료 요청")
     public ApiResponse<MissionRequestResponse> requestMissionApproval(
             @Parameter(hidden = true) @CustomerId Long customerId, @PathVariable Long missionId) {

--- a/src/main/java/com/project/domain/policy/controller/PolicyController.java
+++ b/src/main/java/com/project/domain/policy/controller/PolicyController.java
@@ -5,6 +5,7 @@ import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -56,6 +58,7 @@ public class PolicyController {
 
     @PostMapping
     @AdminOnly
+    @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "정책 생성", description = "새로운 정책 템플릿을 생성합니다.")
     public ApiResponse<PolicyResponse.Create> createPolicy(
             @Valid @RequestBody PolicyRequest.Create policyRequest) {

--- a/src/main/java/com/project/domain/policy/controller/PolicyController.java
+++ b/src/main/java/com/project/domain/policy/controller/PolicyController.java
@@ -63,7 +63,7 @@ public class PolicyController {
     public ApiResponse<PolicyResponse.Create> createPolicy(
             @Valid @RequestBody PolicyRequest.Create policyRequest) {
         Policy policy = policyService.createPolicy(policyRequest);
-        return ApiResponse.success(PolicyResponse.Create.from(policy));
+        return ApiResponse.created(PolicyResponse.Create.from(policy));
     }
 
     @PutMapping("/{policyId}")

--- a/src/main/java/com/project/domain/reward/controller/AdminRewardTemplateController.java
+++ b/src/main/java/com/project/domain/reward/controller/AdminRewardTemplateController.java
@@ -78,7 +78,6 @@ public class AdminRewardTemplateController {
 
     @DeleteMapping("/{id}")
     @AdminOnly
-    @ResponseStatus(HttpStatus.NO_CONTENT)
     @Operation(summary = "보상 템플릿 삭제", description = "보상 템플릿을 삭제합니다. (Soft Delete)")
     public ApiResponse<Void> deleteTemplate(
             @Parameter(description = "보상 템플릿 ID", required = true) @PathVariable("id") Long id) {

--- a/src/test/java/com/project/domain/mission/controller/MissionControllerIntegrationTest.java
+++ b/src/test/java/com/project/domain/mission/controller/MissionControllerIntegrationTest.java
@@ -178,7 +178,7 @@ class MissionControllerIntegrationTest {
                                         .header("Authorization", "Bearer " + OWNER_TOKEN)
                                         .contentType(MediaType.APPLICATION_JSON)
                                         .content(createBody))
-                        .andExpect(status().isOk())
+                        .andExpect(status().isCreated())
                         .andReturn();
         Long createdMissionId =
                 objectMapper
@@ -192,7 +192,7 @@ class MissionControllerIntegrationTest {
                 mockMvc.perform(
                                 post("/missions/{missionId}/request", mission.getId())
                                         .header("Authorization", "Bearer " + MEMBER_TOKEN))
-                        .andExpect(status().isOk())
+                        .andExpect(status().isCreated())
                         .andReturn();
         JsonNode requestData =
                 objectMapper

--- a/src/test/java/com/project/domain/reward/controller/RewardControllerIntegrationTest.java
+++ b/src/test/java/com/project/domain/reward/controller/RewardControllerIntegrationTest.java
@@ -162,7 +162,7 @@ class RewardControllerIntegrationTest {
                 mockMvc.perform(
                                 post("/missions/{missionId}/request", mission.getId())
                                         .header("Authorization", "Bearer " + MEMBER_TOKEN))
-                        .andExpect(status().isOk())
+                        .andExpect(status().isCreated())
                         .andReturn();
         Long requestId =
                 objectMapper


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

- closed: #126 
- jira: DABOM-498

---

## 🎯 목적

프로젝트의 공통 `ApiResponse` 계약과 HTTP 상태 코드가 어긋난 API를 정리합니다.
- 리소스 생성 API는 `201 Created`를 반환하도록 통일
- `204 No Content`와 JSON 래퍼를 동시에 사용하는 모순된 계약 수정
- 스타일 가이드 Section 5에 따라 생성 API는 `ApiResponse.created()` 사용으로 통일

## 📝 변경 사항

- `POST /customers/signup`: `@ResponseStatus(HttpStatus.CREATED)` 추가, `ApiResponse.created()` 적용
- `POST /admin/signup`: `@ResponseStatus(HttpStatus.CREATED)` 추가, `ApiResponse.created()` 적용
- `POST /policies`: `@ResponseStatus(HttpStatus.CREATED)` 추가, `ApiResponse.created()` 적용
- `POST /appeals`: `@ResponseStatus(HttpStatus.CREATED)` 추가
- `POST /appeals/{appealId}/comments`: `@ResponseStatus(HttpStatus.CREATED)` 추가
- `POST /appeals/emergency`: `@ResponseStatus(HttpStatus.CREATED)` 추가
- `POST /missions`: `@ResponseStatus(HttpStatus.CREATED)` 추가
- `POST /missions/{missionId}/request`: `@ResponseStatus(HttpStatus.CREATED)` 추가, `ApiResponse.created()` 적용
- `DELETE /admin/rewards/templates/{id}`: `@ResponseStatus(HttpStatus.NO_CONTENT)` 제거 → `200 OK` 반환

## 📂 변경 범위

| 도메인 | controller | service | repository | entity | infra | global |
| :----: | :--------: | :-----: | :--------: | :----: | :---: | :----: |
| customer |    [x]     |         |            |        |       |        |
| admin |    [x]     |         |            |        |       |        |
| policy |    [x]     |         |            |        |       |        |
| appeal |    [x]     |         |            |        |       |        |
| mission |    [x]     |         |            |        |       |        |
| reward |    [x]     |         |            |        |       |        |

---

## 🖥️ 주요 코드 설명

```java
// 생성 API에 @ResponseStatus(HttpStatus.CREATED) 추가 (Option A 방식)
@PostMapping("/signup")
@ResponseStatus(HttpStatus.CREATED)
@Operation(summary = "사용자 회원가입")
public ApiResponse<SignUpResponse> signUp(...) {
    return ApiResponse.created(customerService.signUp(requestDto));
}
```

```java
// 삭제 API에서 204 선언 제거 — ApiResponse.success(null) 반환 시 200 OK가 올바른 상태 코드
@DeleteMapping("/{id}")
@AdminOnly
// @ResponseStatus(HttpStatus.NO_CONTENT) ← 제거
@Operation(summary = "보상 템플릿 삭제")
public ApiResponse<Void> deleteTemplate(...) {
    rewardTemplateService.deleteTemplate(id);
    return ApiResponse.success(null);
}
```

## 💬 리뷰어에게

- `ApiResponse.created()`는 래퍼의 `message` 필드만 변경하고 HTTP 상태 코드는 바꾸지 않으므로, `@ResponseStatus` 어노테이션으로 실제 상태 코드를 제어합니다.
- controller 레이어만 변경하며, service/repository/entity 변경은 없습니다.
- Spotless / Checkstyle 검증 통과 확인 완료.

---

## 📋 체크리스트

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [x] 전체 변경사항이 500줄을 넘지 않는가?

**코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → Repository → Entity`)
- [x] Setter 없이 비즈니스 메서드로 상태를 변경하는가?
- [x] `@Transactional`은 Service에만 선언했는가?

**테스트**
- [ ] 신규 비즈니스 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

- 변경 파일 6개, 변경사항 총 27줄 (추가 22줄, 삭제 5줄)
- 비즈니스 로직 변경 없이 상태 코드와 응답 래퍼 메서드만 수정
- 프런트엔드가 `200 + success=true`에 의존하는 경우 배포 전 클라이언트 영향 확인 필요