### PR TITLE
[DABOM-503] 정책 수정 시 {"limitBytes":null}(데이터 무제한) 허용이 안되는 현상 수정

### DIFF
--- a/src/main/java/com/project/domain/customer/entity/CustomerQuota.java
+++ b/src/main/java/com/project/domain/customer/entity/CustomerQuota.java
@@ -93,7 +93,7 @@ public class CustomerQuota extends BaseEntity {
             return;
         }
 
-        if (exceededReason.equals(blockReason)) {
+        if (java.util.Objects.equals(exceededReason, blockReason)) {
             this.isBlocked = false;
             this.blockReason = null;
         }

--- a/src/main/java/com/project/domain/customer/entity/CustomerQuota.java
+++ b/src/main/java/com/project/domain/customer/entity/CustomerQuota.java
@@ -87,6 +87,18 @@ public class CustomerQuota extends BaseEntity {
         }
     }
 
+    public void refreshQuotaExceededBlock(boolean enforceLimit, String exceededReason) {
+        if (enforceLimit && isLimitExceeded()) {
+            block(exceededReason);
+            return;
+        }
+
+        if (exceededReason.equals(blockReason)) {
+            this.isBlocked = false;
+            this.blockReason = null;
+        }
+    }
+
     public boolean unblockIfWithinLimit() {
         if (isLimitExceeded()) {
             return false;

--- a/src/main/java/com/project/domain/policy/service/FamilyPolicyServiceImpl.java
+++ b/src/main/java/com/project/domain/policy/service/FamilyPolicyServiceImpl.java
@@ -41,6 +41,7 @@ public class FamilyPolicyServiceImpl implements FamilyPolicyService {
 
     private static final String MANUAL_BLOCK_REASON = "MANUAL_BLOCK";
     private static final String QUOTA_EXCEEDED_REASON = "QUOTA_EXCEEDED";
+    private static final double BYTES_PER_GIGABYTE = 1024.0 * 1024.0 * 1024.0;
 
     private final PolicyAssignmentRepository policyAssignmentRepository;
     private final PolicyQueryRepository policyQueryRepository;
@@ -296,7 +297,7 @@ public class FamilyPolicyServiceImpl implements FamilyPolicyService {
         if (newLimitBytes == null) {
             return "개인 데이터 사용 한도가 무제한으로 변경되었어요.";
         }
-        double limitInGb = newLimitBytes / 1024d / 1024d / 1024d;
+        double limitInGb = newLimitBytes / BYTES_PER_GIGABYTE;
         return "개인 데이터 사용 한도가 %.2fGB로 변경되었어요.".formatted(limitInGb);
     }
 

--- a/src/main/java/com/project/domain/policy/service/FamilyPolicyServiceImpl.java
+++ b/src/main/java/com/project/domain/policy/service/FamilyPolicyServiceImpl.java
@@ -188,20 +188,13 @@ public class FamilyPolicyServiceImpl implements FamilyPolicyService {
             boolean effectiveIsActive,
             Long actorId) {
         CustomerQuota customerQuota = getCurrentMonthCustomerQuota(familyId, targetCustomerId);
-        long newLimitBytes;
-        try {
-            newLimitBytes =
-                    Long.parseLong(
-                            policyConstraintValueNormalizer.normalizeValue(
-                                    PolicyType.MONTHLY_LIMIT, effectiveRules));
-        } catch (NumberFormatException e) {
-            throw new ApplicationException(PolicyErrorCode.INVALID_POLICY_CONSTRAINT_VALUE);
-        }
+        String normalizedLimitValue =
+                policyConstraintValueNormalizer.normalizeValue(
+                        PolicyType.MONTHLY_LIMIT, effectiveRules);
+        Long newLimitBytes = parseMonthlyLimitBytes(normalizedLimitValue);
 
         customerQuota.changeMonthlyLimitBytes(newLimitBytes);
-        if (effectiveIsActive) {
-            customerQuota.blockIfLimitExceeded(QUOTA_EXCEEDED_REASON);
-        }
+        customerQuota.refreshQuotaExceededBlock(effectiveIsActive, QUOTA_EXCEEDED_REASON);
 
         notificationOutboxPublisher.enqueueAndPublishAfterCommit(
                 new NotificationPayload(
@@ -288,7 +281,21 @@ public class FamilyPolicyServiceImpl implements FamilyPolicyService {
                         () -> new ApplicationException(CustomerErrorCode.CUSTOMER_QUOTA_NOT_FOUND));
     }
 
-    private String buildQuotaUpdatedMessage(long newLimitBytes) {
+    private Long parseMonthlyLimitBytes(String normalizedLimitValue) {
+        if (normalizedLimitValue == null) {
+            return null;
+        }
+        try {
+            return Long.parseLong(normalizedLimitValue);
+        } catch (NumberFormatException e) {
+            throw new ApplicationException(PolicyErrorCode.INVALID_POLICY_CONSTRAINT_VALUE);
+        }
+    }
+
+    private String buildQuotaUpdatedMessage(Long newLimitBytes) {
+        if (newLimitBytes == null) {
+            return "개인 데이터 사용 한도가 무제한으로 변경되었어요.";
+        }
         double limitInGb = newLimitBytes / 1024d / 1024d / 1024d;
         return "개인 데이터 사용 한도가 %.2fGB로 변경되었어요.".formatted(limitInGb);
     }
@@ -298,7 +305,7 @@ public class FamilyPolicyServiceImpl implements FamilyPolicyService {
             Long targetCustomerId,
             boolean effectiveIsActive,
             Long actorId,
-            long newLimitBytes) {
+            Long newLimitBytes) {
         Map<String, Object> data =
                 new LinkedHashMap<>(
                         buildPolicyNotificationData(

--- a/src/main/java/com/project/domain/policy/service/helper/PolicyConstraintValueNormalizer.java
+++ b/src/main/java/com/project/domain/policy/service/helper/PolicyConstraintValueNormalizer.java
@@ -1,5 +1,6 @@
 package com.project.domain.policy.service.helper;
 
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -42,7 +43,9 @@ public class PolicyConstraintValueNormalizer {
 
     public String serializeMonthlyLimitRule(Long limitBytes) {
         try {
-            return objectMapper.writeValueAsString(Map.of(LIMIT_BYTES, limitBytes));
+            Map<String, Object> rules = new LinkedHashMap<>();
+            rules.put(LIMIT_BYTES, limitBytes);
+            return objectMapper.writeValueAsString(rules);
         } catch (JsonProcessingException e) {
             throw new ApplicationException(PolicyErrorCode.POLICY_RULES_SERIALIZATION_FAILED);
         }
@@ -57,8 +60,11 @@ public class PolicyConstraintValueNormalizer {
     }
 
     private String normalizeMonthlyLimit(Map<String, Object> rules) {
-        // {"limitBytes": 123} -> "123"
+        // {"limitBytes": 123} -> "123", {"limitBytes": null} -> null(무제한)
         Object limitBytesObj = rules.get(LIMIT_BYTES);
+        if (limitBytesObj == null) {
+            return null;
+        }
         return String.valueOf(toPositiveLong(limitBytesObj, LIMIT_BYTES));
     }
 


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

<!-- 이슈 넘버와 티켓 넘버를 작성해주세요. 이슈가 닫히는 것을 원치 않으면 closed:를 지워주세요 -->

- closed: #127 
- jira: DABOM-503

---

## 🎯 목적

<!-- 왜 이 변경이 필요한지 배경과 목적을 작성해주세요. -->
정책 수정 시 {"limitBytes":null}(데이터 무제한) 허용이 안되어 데이터 무제한으로 변경이 안되던 현상을 수정하기 위함

## 📝 변경 사항

<!-- 무엇을 변경했는지 리스트로 작성해주세요. -->

- 월간 데이터 제한 정책 정규화 로직에서 `{"limitBytes": null}` 값을 무제한으로 처리하도록 수정
- 정책 수정 시 `limitBytes`가 `null`이어도 예외 없이 quota 변경이 가능하도록 서비스 로직 수정
- 제한 해제 시 기존 quota 초과 차단 상태가 적절히 해제되도록 `CustomerQuota` 갱신 로직 추가
- 알림 문구가 무제한 변경 케이스를 올바르게 표시하도록 수정

## 📂 변경 범위

<!-- 변경된 도메인/레이어를 표시해주세요. 해당 항목에 [x]로 체크해주세요. -->

| 도메인 | controller | service | repository | entity | infra | global |
| :----: | :--------: | :-----: | :--------: | :----: | :---: | :----: |
|   policy / customer     |            |      [x]   |           |   [x]     |       |        |

---

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. 단순 변경이면 섹션을 지워도 됩니다. -->

```java
// {"limitBytes": null} 인 경우 null을 그대로 반환해 무제한 정책으로 처리
private String normalizeMonthlyLimit(Map<String, Object> rules) {
    Object limitBytesObj = rules.get(LIMIT_BYTES);
    if (limitBytesObj == null) {
        return null;
    }
    return String.valueOf(toPositiveLong(limitBytesObj, LIMIT_BYTES));
}
```

## 💬 리뷰어에게

<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->

- limitBytes=null이 "무제한" 의미로 전체 흐름에서 자연스럽게 처리되는지 중심으로 봐주시면 됩니다.

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [x] 전체 변경사항이 500줄을 넘지 않는가?

**코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → Repository → Entity`)
- [x] Setter 없이 비즈니스 메서드로 상태를 변경하는가?
- [x] `@Transactional`은 Service에만 선언했는가?

**테스트**
- [x] 신규 비즈니스 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

<!-- 추가로 공유할 내용이 있으면 작성해주세요. (관련 문서 링크, 후속 작업 등) -->
