### PR TITLE
[DABOM-509] MissionCardResponse 응답에 requestId 추가 및 조회 로직 추가

### DIFF
--- a/src/main/java/com/project/common/config/WebConfig.java
+++ b/src/main/java/com/project/common/config/WebConfig.java
@@ -32,8 +32,7 @@ public class WebConfig implements WebMvcConfigurer {
     public CorsFilter corsFilter() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowedOrigins(List.of(allowedOrigins));
-        config.setAllowedMethods(
-                List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         config.addAllowedHeader("*");
         config.setAllowCredentials(true);
 

--- a/src/main/java/com/project/domain/mission/dto/response/MissionCardResponse.java
+++ b/src/main/java/com/project/domain/mission/dto/response/MissionCardResponse.java
@@ -8,6 +8,7 @@ import com.project.domain.reward.dto.response.RewardResponse;
 /** 미션 카드 응답 DTO */
 public record MissionCardResponse(
         Long missionItemId,
+        Long requestId,
         String missionText,
         String requestStatus,
         CustomerSimpleResponse target,
@@ -17,6 +18,7 @@ public record MissionCardResponse(
     public static MissionCardResponse from(MissionListResult.MissionCard card) {
         return new MissionCardResponse(
                 card.missionItemId(),
+                card.requestId(),
                 card.missionText(),
                 card.requestStatus(),
                 CustomerSimpleResponse.from(card.target()),

--- a/src/main/java/com/project/domain/mission/model/MissionListResult.java
+++ b/src/main/java/com/project/domain/mission/model/MissionListResult.java
@@ -11,6 +11,7 @@ public record MissionListResult(List<MissionCard> missions, String nextCursor, b
     /** 목록 카드 단위 모델 */
     public record MissionCard(
             Long missionItemId,
+            Long requestId,
             String missionText,
             String requestStatus,
             CustomerSummary target,

--- a/src/main/java/com/project/domain/mission/repository/MissionRequestRepository.java
+++ b/src/main/java/com/project/domain/mission/repository/MissionRequestRepository.java
@@ -60,17 +60,6 @@ public interface MissionRequestRepository extends JpaRepository<MissionRequest, 
             """
             select mr
             from MissionRequest mr
-            where mr.missionItemId in :missionItemIds
-              and mr.status = :status
-            order by mr.createdAt desc, mr.id desc
-            """)
-    List<MissionRequest> findByMissionItemIdInAndStatusOrderByCreatedAtDescIdDesc(
-            Set<Long> missionItemIds, MissionRequestStatus status);
-
-    @Query(
-            """
-            select mr
-            from MissionRequest mr
             where mr.requesterId = :requesterId
               and mr.status = :status
               and mr.resolvedAt is not null

--- a/src/main/java/com/project/domain/mission/repository/MissionRequestRepository.java
+++ b/src/main/java/com/project/domain/mission/repository/MissionRequestRepository.java
@@ -60,6 +60,17 @@ public interface MissionRequestRepository extends JpaRepository<MissionRequest, 
             """
             select mr
             from MissionRequest mr
+            where mr.missionItemId in :missionItemIds
+              and mr.status = :status
+            order by mr.createdAt desc, mr.id desc
+            """)
+    List<MissionRequest> findByMissionItemIdInAndStatusOrderByCreatedAtDescIdDesc(
+            Set<Long> missionItemIds, MissionRequestStatus status);
+
+    @Query(
+            """
+            select mr
+            from MissionRequest mr
             where mr.requesterId = :requesterId
               and mr.status = :status
               and mr.resolvedAt is not null

--- a/src/main/java/com/project/domain/mission/service/MissionServiceImpl.java
+++ b/src/main/java/com/project/domain/mission/service/MissionServiceImpl.java
@@ -1,5 +1,6 @@
 package com.project.domain.mission.service;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -76,8 +77,17 @@ public class MissionServiceImpl implements MissionService {
         String nextCursor = hasNext ? String.valueOf(page.getLast().getId()) : null;
 
         Map<Long, String> customerNameMap = loadCustomerNameMap(page);
-        Map<Long, String> requestStatusMap = loadMissionRequestStatusMap(page);
-        Map<Long, Long> pendingRequestIdMap = loadPendingMissionRequestIdMap(page);
+        Map<Long, MissionRequest> latestRequestMap = loadLatestMissionRequestMap(page);
+        Map<Long, String> requestStatusMap = new HashMap<>();
+        Map<Long, Long> pendingRequestIdMap = new HashMap<>();
+
+        latestRequestMap.forEach(
+                (missionId, request) -> {
+                    requestStatusMap.put(missionId, request.getStatus().name());
+                    if (request.isPending()) {
+                        pendingRequestIdMap.put(missionId, request.getId());
+                    }
+                });
 
         return new MissionListResult(
                 page.stream()
@@ -314,7 +324,7 @@ public class MissionServiceImpl implements MissionService {
     }
 
     /** 미션별 최신 요청 상태를 맵 형태로 조회한다. */
-    private Map<Long, String> loadMissionRequestStatusMap(List<MissionItem> missions) {
+    private Map<Long, MissionRequest> loadLatestMissionRequestMap(List<MissionItem> missions) {
         Set<Long> missionIds =
                 missions.stream().map(MissionItem::getId).collect(Collectors.toSet());
         return missionRequestRepository
@@ -323,21 +333,7 @@ public class MissionServiceImpl implements MissionService {
                 .collect(
                         Collectors.toMap(
                                 MissionRequest::getMissionItemId,
-                                request -> request.getStatus().name(),
-                                (latest, ignored) -> latest));
-    }
-
-    private Map<Long, Long> loadPendingMissionRequestIdMap(List<MissionItem> missions) {
-        Set<Long> missionIds =
-                missions.stream().map(MissionItem::getId).collect(Collectors.toSet());
-        return missionRequestRepository
-                .findByMissionItemIdInAndStatusOrderByCreatedAtDescIdDesc(
-                        missionIds, MissionRequestStatus.PENDING)
-                .stream()
-                .collect(
-                        Collectors.toMap(
-                                MissionRequest::getMissionItemId,
-                                MissionRequest::getId,
+                                Function.identity(),
                                 (latest, ignored) -> latest));
     }
 

--- a/src/main/java/com/project/domain/mission/service/MissionServiceImpl.java
+++ b/src/main/java/com/project/domain/mission/service/MissionServiceImpl.java
@@ -77,10 +77,17 @@ public class MissionServiceImpl implements MissionService {
 
         Map<Long, String> customerNameMap = loadCustomerNameMap(page);
         Map<Long, String> requestStatusMap = loadMissionRequestStatusMap(page);
+        Map<Long, Long> pendingRequestIdMap = loadPendingMissionRequestIdMap(page);
 
         return new MissionListResult(
                 page.stream()
-                        .map(mission -> toMissionCard(mission, customerNameMap, requestStatusMap))
+                        .map(
+                                mission ->
+                                        toMissionCard(
+                                                mission,
+                                                customerNameMap,
+                                                requestStatusMap,
+                                                pendingRequestIdMap))
                         .toList(),
                 nextCursor,
                 hasNext);
@@ -289,9 +296,11 @@ public class MissionServiceImpl implements MissionService {
     private MissionListResult.MissionCard toMissionCard(
             MissionItem mission,
             Map<Long, String> customerNameMap,
-            Map<Long, String> requestStatusMap) {
+            Map<Long, String> requestStatusMap,
+            Map<Long, Long> pendingRequestIdMap) {
         return new MissionListResult.MissionCard(
                 mission.getId(),
+                pendingRequestIdMap.get(mission.getId()),
                 mission.getMissionText(),
                 requestStatusMap.get(mission.getId()),
                 new MissionListResult.CustomerSummary(
@@ -315,6 +324,20 @@ public class MissionServiceImpl implements MissionService {
                         Collectors.toMap(
                                 MissionRequest::getMissionItemId,
                                 request -> request.getStatus().name(),
+                                (latest, ignored) -> latest));
+    }
+
+    private Map<Long, Long> loadPendingMissionRequestIdMap(List<MissionItem> missions) {
+        Set<Long> missionIds =
+                missions.stream().map(MissionItem::getId).collect(Collectors.toSet());
+        return missionRequestRepository
+                .findByMissionItemIdInAndStatusOrderByCreatedAtDescIdDesc(
+                        missionIds, MissionRequestStatus.PENDING)
+                .stream()
+                .collect(
+                        Collectors.toMap(
+                                MissionRequest::getMissionItemId,
+                                MissionRequest::getId,
                                 (latest, ignored) -> latest));
     }
 

--- a/src/test/java/com/project/domain/mission/controller/MissionControllerIntegrationTest.java
+++ b/src/test/java/com/project/domain/mission/controller/MissionControllerIntegrationTest.java
@@ -388,6 +388,45 @@ class MissionControllerIntegrationTest {
         assertThat(foundMission).isNotNull();
         assertThat(Objects.requireNonNull(foundMission).path("requestStatus").asText())
                 .isEqualTo("REJECTED");
+        assertThat(foundMission.path("requestId").isNull()).isTrue();
+    }
+
+    @Test
+    @DisplayName("미션 목록은 PENDING 요청이 있으면 requestId를 함께 반환한다")
+    void missionListIncludesPendingRequestId() throws Exception {
+        MissionRequest request =
+                missionRequestRepository.save(
+                        MissionRequest.builder()
+                                .missionItemId(mission.getId())
+                                .requesterId(member.getId())
+                                .status(MissionRequestStatus.PENDING)
+                                .build());
+
+        MvcResult result =
+                mockMvc.perform(
+                                get("/missions")
+                                        .header("Authorization", "Bearer " + MEMBER_TOKEN)
+                                        .param("size", "20"))
+                        .andExpect(status().isOk())
+                        .andReturn();
+
+        JsonNode missions =
+                objectMapper
+                        .readTree(result.getResponse().getContentAsString())
+                        .path("data")
+                        .path("missions");
+        JsonNode foundMission = null;
+        for (JsonNode node : missions) {
+            if (node.path("missionItemId").asLong() == mission.getId()) {
+                foundMission = node;
+                break;
+            }
+        }
+
+        assertThat(foundMission).isNotNull();
+        assertThat(Objects.requireNonNull(foundMission).path("requestId").asLong())
+                .isEqualTo(request.getId());
+        assertThat(foundMission.path("requestStatus").asText()).isEqualTo("PENDING");
     }
 
     @Test

--- a/src/test/java/com/project/domain/mission/service/MissionServiceImplTest.java
+++ b/src/test/java/com/project/domain/mission/service/MissionServiceImplTest.java
@@ -78,18 +78,6 @@ class MissionServiceImplTest {
                                         .requesterId(2L)
                                         .status(MissionRequestStatus.PENDING)
                                         .build()));
-        given(
-                        missionRequestRepository
-                                .findByMissionItemIdInAndStatusOrderByCreatedAtDescIdDesc(
-                                        java.util.Set.of(100L), MissionRequestStatus.PENDING))
-                .willReturn(
-                        List.of(
-                                MissionRequest.builder()
-                                        .id(200L)
-                                        .missionItemId(100L)
-                                        .requesterId(2L)
-                                        .status(MissionRequestStatus.PENDING)
-                                        .build()));
         Customer owner = customer(1L, "owner");
         Customer member = customer(2L, "member");
         given(customerRepository.findAllById(anyIterable())).willReturn(List.of(owner, member));
@@ -136,19 +124,6 @@ class MissionServiceImplTest {
                                         .missionItemId(99L)
                                         .requesterId(2L)
                                         .status(MissionRequestStatus.REJECTED)
-                                        .build()));
-        given(
-                        missionRequestRepository
-                                .findByMissionItemIdInAndStatusOrderByCreatedAtDescIdDesc(
-                                        java.util.Set.of(100L, 99L, 98L),
-                                        MissionRequestStatus.PENDING))
-                .willReturn(
-                        List.of(
-                                MissionRequest.builder()
-                                        .id(201L)
-                                        .missionItemId(100L)
-                                        .requesterId(2L)
-                                        .status(MissionRequestStatus.PENDING)
                                         .build()));
         Customer owner = customer(1L, "owner");
         Customer member = customer(2L, "member");

--- a/src/test/java/com/project/domain/mission/service/MissionServiceImplTest.java
+++ b/src/test/java/com/project/domain/mission/service/MissionServiceImplTest.java
@@ -78,6 +78,18 @@ class MissionServiceImplTest {
                                         .requesterId(2L)
                                         .status(MissionRequestStatus.PENDING)
                                         .build()));
+        given(
+                        missionRequestRepository
+                                .findByMissionItemIdInAndStatusOrderByCreatedAtDescIdDesc(
+                                        java.util.Set.of(100L), MissionRequestStatus.PENDING))
+                .willReturn(
+                        List.of(
+                                MissionRequest.builder()
+                                        .id(200L)
+                                        .missionItemId(100L)
+                                        .requesterId(2L)
+                                        .status(MissionRequestStatus.PENDING)
+                                        .build()));
         Customer owner = customer(1L, "owner");
         Customer member = customer(2L, "member");
         given(customerRepository.findAllById(anyIterable())).willReturn(List.of(owner, member));
@@ -85,6 +97,7 @@ class MissionServiceImplTest {
         var result = missionService.listMissions(auth, null, 20);
 
         assertThat(result.missions()).hasSize(1);
+        assertThat(result.missions().getFirst().requestId()).isEqualTo(200L);
         assertThat(result.missions().getFirst().requestStatus()).isEqualTo("PENDING");
         assertThat(result.missions().getFirst().reward().rewardId()).isEqualTo(900L);
         assertThat(result.missions().getFirst().reward().templateId()).isEqualTo(500L);
@@ -124,6 +137,19 @@ class MissionServiceImplTest {
                                         .requesterId(2L)
                                         .status(MissionRequestStatus.REJECTED)
                                         .build()));
+        given(
+                        missionRequestRepository
+                                .findByMissionItemIdInAndStatusOrderByCreatedAtDescIdDesc(
+                                        java.util.Set.of(100L, 99L, 98L),
+                                        MissionRequestStatus.PENDING))
+                .willReturn(
+                        List.of(
+                                MissionRequest.builder()
+                                        .id(201L)
+                                        .missionItemId(100L)
+                                        .requesterId(2L)
+                                        .status(MissionRequestStatus.PENDING)
+                                        .build()));
         Customer owner = customer(1L, "owner");
         Customer member = customer(2L, "member");
         given(customerRepository.findAllById(anyIterable())).willReturn(List.of(owner, member));
@@ -136,8 +162,11 @@ class MissionServiceImplTest {
                                 .map(MissionListResult.MissionCard::missionItemId)
                                 .toList())
                 .containsExactly(100L, 99L, 98L);
+        assertThat(result.missions().get(0).requestId()).isEqualTo(201L);
         assertThat(result.missions().get(0).requestStatus()).isEqualTo("PENDING");
+        assertThat(result.missions().get(1).requestId()).isNull();
         assertThat(result.missions().get(1).requestStatus()).isEqualTo("REJECTED");
+        assertThat(result.missions().get(2).requestId()).isNull();
         assertThat(result.missions().get(2).requestStatus()).isNull();
     }
 


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

<!-- 이슈 넘버와 티켓 넘버를 작성해주세요. 이슈가 닫히는 것을 원치 않으면 closed:를 지워주세요 -->

- closed: #130 
- jira: DABOM-509

---

## 🎯 목적

<!-- 왜 이 변경이 필요한지 배경과 목적을 작성해주세요. -->
미션 목록 카드 응답에서 진행 중인 완료 요청을 식별할 수 있도록 `PENDING` 상태의 `MissionRequest.id`를 함께 내려주기 위함

## 📝 변경 사항

<!-- 무엇을 변경했는지 리스트로 작성해주세요. -->

- `MissionCardResponse`에 `requestId` 필드 추가
- 미션 목록 조회 시 `requestStatus`는 기존대로 유지하고, `PENDING` 요청의 `requestId`만 별도 조회하도록 분리
- 관련 서비스/통합 테스트 검증 로직 수정

## 📂 변경 범위

<!-- 변경된 도메인/레이어를 표시해주세요. 해당 항목에 [x]로 체크해주세요. -->

| 도메인 | controller | service | repository | entity | infra | global |
| :----: | :--------: | :-----: | :--------: | :----: | :---: | :----: |
|    mission    |            |      [x]   |     [x]       |        |       |        |

---

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. 단순 변경이면 섹션을 지워도 됩니다. -->

```java
Map<Long, String> requestStatusMap = loadMissionRequestStatusMap(page);
Map<Long, Long> pendingRequestIdMap = loadPendingMissionRequestIdMap(page);

return new MissionListResult(
        page.stream()
                .map(
                        mission ->
                                toMissionCard(
                                        mission,
                                        customerNameMap,
                                        requestStatusMap,
                                        pendingRequestIdMap))
                .toList(),
        nextCursor,
        hasNext);

private Map<Long, Long> loadPendingMissionRequestIdMap(List<MissionItem> missions) {
    Set<Long> missionIds =
            missions.stream().map(MissionItem::getId).collect(Collectors.toSet());
    return missionRequestRepository
            .findByMissionItemIdInAndStatusOrderByCreatedAtDescIdDesc(
                    missionIds, MissionRequestStatus.PENDING)
            .stream()
            .collect(
                    Collectors.toMap(
                            MissionRequest::getMissionItemId,
                            MissionRequest::getId,
                            (latest, ignored) -> latest));
}
```

## 💬 리뷰어에게

<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
미션 목록의 requestStatus는 기존 의미를 유지하고, requestId만 PENDING 요청 기준으로 추가했습니다.

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [x] 전체 변경사항이 500줄을 넘지 않는가?

**코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → Repository → Entity`)
- [x] Setter 없이 비즈니스 메서드로 상태를 변경하는가?
- [x] `@Transactional`은 Service에만 선언했는가?

**테스트**
- [x] 신규 비즈니스 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

<!-- 추가로 공유할 내용이 있으면 작성해주세요. (관련 문서 링크, 후속 작업 등) -->
